### PR TITLE
Add quick fix for service manager.

### DIFF
--- a/app/controllers/auth/ChildBenefitAuth.scala
+++ b/app/controllers/auth/ChildBenefitAuth.scala
@@ -115,7 +115,7 @@ trait ChildBenefitAuth extends AuthorisedFunctions with AuthRedirects with Loggi
   private def toContinueUrl(call: Call)(implicit rh: RequestHeader, env: Environment): String = {
     env.mode match {
       case Dev => call.absoluteURL()
-      case _   => call.url
+      case _   => call.absoluteURL()
     }
   }
 


### PR DESCRIPTION
Unfortunatelly service manager is running in Prod mode and and I don't think we can configure it via command line parameters to run in Dev mode. This will generate always absolute URL.