### PR TITLE
SB-1169: Do not show front end errors to users

### DIFF
--- a/test/controllers/ProofOfEntitlementControllerSpec.scala
+++ b/test/controllers/ProofOfEntitlementControllerSpec.scala
@@ -49,7 +49,7 @@ class ProofOfEntitlementControllerSpec extends BaseISpec with EitherValues {
   implicit val hc:      HeaderCarrier                       = HeaderCarrier()
 
   "Proof of entitlement controller" - {
-    "must return INTERNAL_SERVER_ERROR and render the error view for a GET when getting entitlement fails" in {
+    "must return SEE_OTHER and redirect to the service down view for a GET when getting entitlement fails" in {
       userLoggedInChildBenefitUser(NinoUser)
 
       val failingChildBenefitEntitlementConnector = new ChildBenefitEntitlementConnector {
@@ -83,7 +83,7 @@ class ProofOfEntitlementControllerSpec extends BaseISpec with EitherValues {
 
         maybeEntitlement.isLeft mustBe true
 
-        status(result) mustEqual INTERNAL_SERVER_ERROR
+        status(result) mustEqual SEE_OTHER
         assertSameHtmlAfter(removeNonce)(
           contentAsString(result),
           contentAsString(


### PR DESCRIPTION
[SB-1169](https://jira.tools.tax.service.gov.uk/browse/SB-1169)

Pushing error content out to user in the case of an internal service error is undesired for the platform going live as these typically contain technical or possible sensitive details.
Rather we will now ensure they are logged and redirect to the Service Down page to avoid anything internal being displayed