### PR TITLE
Hide the back link element when JS is disabled

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,13 @@
+// ----------------
+// Hide the back link when body does not have .js-enabled
+// Any further such elements that require suppression can be added here
+// ----------------
+
+body:not(.js-enabled) {
+    .govuk-back-link {
+        display: none;
+        visibility: hidden;
+        width: 0;
+        height: 0;
+    }
+}

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -50,6 +50,7 @@
       ))
   }
   <link href='@controllers.routes.Assets.versioned("stylesheets/print.css")' media="all" rel="stylesheet" type="text/css" />
+  <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="all" rel="stylesheet" type="text/css" />
 }
 
 @customTechnicalProblemLinkSection(uri: String) = {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.21.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.29.0-play-28",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.11.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.24.0",
     "uk.gov.hmrc"       %% "play-language"                 % "5.3.0-play-28",


### PR DESCRIPTION
[SB-1327](https://jira.tools.tax.service.gov.uk/browse/SB-1327)
I spoke with the platform ui team and this is now standard way to suppress elements that require javascript functionality.
Functionally was introduced that add a "js-enabled" class the the body only if JS is itself enabled and this can be used to conditionally hide elements if it is not present.

JS Enabled:
<img width="702" alt="image" src="https://user-images.githubusercontent.com/11579453/213435908-1dc91550-b2db-41d4-a72e-5edc67e43a1b.png">

JS Disabled:
<img width="702" alt="image" src="https://user-images.githubusercontent.com/11579453/213436112-8bdaaf92-01d3-4fa6-b12f-e1c7cbc118bb.png">
