### PR TITLE
SB-1326: Welsh translations from Accessibility assessment

### DIFF
--- a/app/views/UnauthorisedView.scala.html
+++ b/app/views/UnauthorisedView.scala.html
@@ -44,8 +44,5 @@
     pageTitle = titleNoForm(messages("unauthorised.title")),
     timeout   = false
 ) {
-
     @heading(messages("unauthorised.heading"))
-
-    @para(messages("unauthorised.guidance"))
 }

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -23,7 +23,7 @@
 @this(
         appConfig: FrontendAppConfig,
         hmrcLayout: HmrcLayout,
-        hmrcTimeoutDialog: HmrcTimeoutDialog,
+        hmrcTimeoutDialog: HmrcTimeoutDialogHelper,
         govukPhaseBanner: GovukPhaseBanner,
         standardBetaBanner: StandardBetaBanner,
         dataLayerTemplate: DataLayerTemplate
@@ -38,16 +38,15 @@
 @customAdditionalHeadBlock = {
   @if(timeout) {
       @hmrcTimeoutDialog(
-      TimeoutDialog(
       timeout = Some(appConfig.timeout),
       countdown = Some(appConfig.countdown),
       keepAliveUrl = Some(routes.KeepAliveController.keepAlive.url),
       keepAliveButtonText = Some(messages("timeout.keepAlive")),
-      signOutUrl = Some(controllers.auth.routes.AuthController.signOutNoSurvey.url),
+      signOutUrl = controllers.auth.routes.AuthController.signOutNoSurvey.url,
       signOutButtonText = Some(messages("timeout.signOut")),
       title = Some(messages("timeout.title")),
       message = Some(messages("timeout.message"))
-      ))
+      )
   }
   <link href='@controllers.routes.Assets.versioned("stylesheets/print.css")' media="all" rel="stylesheet" type="text/css" />
   <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="all" rel="stylesheet" type="text/css" />

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1,25 +1,41 @@
 label.back.link=Yn ôl
 
+service.name = Budd-dal Plant
+
+# ---------- Site Section -----------------------
+site.signIn = Mewngofnodi
 site.govuk = GOV.UK
 site.technicalProblemMessage = A yw’r dudalen hon yn gweithio’n iawn? (yn agor mewn tab newydd)
 site.continue = Yn eich blaen
-service.name = Budd-dal Plant
 
-noAccountFound.header=Nid ydych yn hawlio Budd-dal Plant
-noAccountFound.explanation=Ni allwn ddod o hyd i hawliad am Fudd-dal Plant ar eich cyfer.
-noAccountFound.reason=Gall hyn fod oherwydd:
-noAccountFound.bulletPoint1=nid ydych wedi hawlio
-noAccountFound.bulletPoint2=mae hawliad yr ydych wedi’i wneud yn dal i gael ei brosesu
-noAccountFound.bulletPoint3=cafodd yr hawliad ei wneud gan rywun arall - er enghraifft, mae’n bosibl ei fod yn enw eich partner
-noAccountFound.bulletPoint4=nid ydych yn cael Budd-dal Plant mwyach
-noAccountFound.callInfo1=Gallwch ein ffonio os oes angen gwybodaeth arnoch am hawliad sydd wedi dod i ben.
-noAccountFound.callInfo2=Pan fyddwch yn ffonio, bydd arnoch angen eich rhif Yswiriant Gwladol.
+# ---------- Date Section -----------------------
 
-notFound.header=Heb ddod o hyd i’r dudalen
-notFound.explanation1=Os gwnaethoch deipio’r cyfeiriad gwe, gwiriwch ei fod yn gywir.
-notFound.explanation2=Os gwnaethoch ludo’r cyfeiriad gwe, gwiriwch eich bod wedi copïo’r cyfeiriad yn llawn.
+# ---------- Timeout Section --------------------
+timeout.title = Rydych ar fin cael eich allgofnodi
+timeout.message = Er eich diogelwch, byddwn yn eich allgofnodi cyn pen
+timeout.keepAlive = Parhau i fod wedi’ch mewngofnodi
+timeout.signOut = Allgofnodi
 
-# ---------------------------- Helpline Section ----------------------------
+# ---------- Error Section ----------------------
+
+# ---------- Index Section ----------------------
+
+# ---------- Check Your Answers Section ---------
+
+# ---------- Journey Recovery Section -----------
+
+# ---------- Signed Out Section -----------------
+signedOut.title = Er eich diogelwch, gwnaethom eich allgofnodi
+signedOut.heading = Er eich diogelwch, gwnaethom eich allgofnodi
+signedOut.guidance = Ni wnaethom gadw’ch atebion.
+
+# ---------- Unauthorised Section ---------------
+unauthorised.title = Ni allwch gael mynediad at y gwasanaeth hwn gyda’r cyfrif hwn
+unauthorised.heading = Ni allwch gael mynediad at y gwasanaeth hwn gyda’r cyfrif hwn
+
+# ---------- Homepage Section -------------------
+
+# ---------- Helpline Section -------------------
 helpline.info.title = Gwasanaeth Cwsmeriaid Cymraeg CThEM
 helpline.info.telephone = Ffôn: 0300 200 1900
 helpline.info.welshTelephone = Gwasanaeth Saesneg: 0300 200 3100
@@ -29,7 +45,7 @@ helpline.info.availability = Dydd Llun - Dydd Gwener, 08:30 - 17:30
 helpline.info.charges = Gwybodaeth am gostau galwadau
 helpline.info.callChargesUrl = https://www.gov.uk/costau-galwadau
 
-# ---------------------------- Proof Of Entitlement ----------------------------
+# ---------- Proof of Entitlement Section -------
 proofOfEntitlement.title=Tystiolaeth o hawl i Fudd-dal Plant
 proofOfEntitlement.confirmation=Cadarnhad yw hwn gan CThEF o’r hawl i Fudd-dal Plant ar gyfer {0} ar {1}.
 proofOfEntitlement.paidDetail=Caiff Budd-dal Plant ei dalu ar y cyfraddau canlynol:
@@ -52,10 +68,8 @@ proofOfEntitlement.viewpayments=Bwrw golwg dros eich taliadau Budd-dal Plant
 proofOfEntitlement.viewrecentpayments.para = Gallwch {0} a gweld eich 5 dyddiad talu diwethaf a faint a dalwyd i chi.
 proofOfEntitlement.viewrecentpayments.link = fwrw golwg dros eich taliadau Budd-dal Plant diweddar
 proofOfEntitlement.printMessage=Argraffu’r dudalen hon
-# ------------------------------------------------------------------------------------
 
-
-# ---------------------------- View Payment History ----------------------------
+# ---------- Payment History Section ------------
 paymentHistory.pageTitle = Hanes taliadau Budd-dal Plant - Budd-dal Plant - GOV.UK
 paymentHistory.title = Hanes taliadau Budd-dal Plant
 paymentHistory.viewEntitlementProof = Bwrw golwg dros dystiolaeth o’ch hawl i Fudd-dal Plant
@@ -66,7 +80,7 @@ paymentHistory.recentCBPayments.p1 = Y 5 taliad diweddaraf a wnaed yn ystod y 2 
 paymentHistory.table.date = Dyddiad
 paymentHistory.table.amount = Swm
 
-# --------- No Payment History ---------
+# ---------- No Payment History Section ---------
 # ---- Variant 2 - In payment without payments in last 2 years
 paymentHistory.v2.noReceivedPayments=Nid ydych wedi cael unrhyw daliadau yn ystod y 2 flynedd ddiwethaf.
 
@@ -78,7 +92,7 @@ paymentHistory.v4.p2=Mae ein cofnodion yn dangos nad ydych wedi cael unrhyw dali
 paymentHistory.v6.p1=Nid oes gennych hawl i gael Budd-dal Plant, mwyach.
 paymentHistory.v6.p2=Mae ein cofnodion yn dangos nad ydych wedi cael unrhyw daliadau yn ystod y 2 flynedd ddiwethaf.
 
-# --------- Some Payment History ---------
+# ---------- Some Payment History Section -------
 # ---- Variant 1 - In payment with payments in last 2 years
 paymentHistory.v1.header = Cael gwybod pryd y cewch eich talu nesaf
 paymentHistory.v1.p1 = Os ydych yn cael eich talu pob 4 wythnos, gallwch weithio allan pryd y cewch eich talu nesaf drwy rifo 4 wythnos ymlaen o’ch taliad diwethaf.
@@ -93,14 +107,34 @@ paymentHistory.v3.p2=Mae ein cofnodion yn dangos eich bod wedi cael taliad neu d
 # ---- Variant 5 - Entitlement ended but received payments in last 2 year
 paymentHistory.v5.p1=Nid oes gennych hawl i gael Budd-dal Plant, mwyach.
 paymentHistory.v5.p2=Mae ein cofnodion yn dangos eich bod wedi cael taliad neu daliadau yn ystod y 2 flynedd ddiwethaf.
-# ------------------------------------------------------------------------------------
 
+# ---------- Service Unavailable Section --------
 service-unavailable-error-template.heading = Mae’n ddrwg gennym – mae problem gyda’r gwasanaeth
 service-unavailable-error-template.paragraph.1 = Rhowch gynnig arall arni yn nes ymlaen.
 service-unavailable-error-template.paragraph.2 = Gallwch ein ffonio os hoffech siarad â rhywun ynglŷn â’ch dyfarniad Budd-dal Plant.
 service-unavailable-error-template.paragraph.3 = Pan fyddwch yn ffonio, bydd arnoch angen eich rhif Yswiriant Gwladol.
 
-# ---------------------------- Change Of Bank ----------------------------
+# ---------- No Account Found Section -----------
+noAccountFound.header=Nid ydych yn hawlio Budd-dal Plant
+noAccountFound.explanation=Ni allwn ddod o hyd i hawliad am Fudd-dal Plant ar eich cyfer.
+noAccountFound.reason=Gall hyn fod oherwydd:
+noAccountFound.bulletPoint1=nid ydych wedi hawlio
+noAccountFound.bulletPoint2=mae hawliad yr ydych wedi’i wneud yn dal i gael ei brosesu
+noAccountFound.bulletPoint3=cafodd yr hawliad ei wneud gan rywun arall - er enghraifft, mae’n bosibl ei fod yn enw eich partner
+noAccountFound.bulletPoint4=nid ydych yn cael Budd-dal Plant mwyach
+noAccountFound.callInfo1=Gallwch ein ffonio os oes angen gwybodaeth arnoch am hawliad sydd wedi dod i ben.
+noAccountFound.callInfo2=Pan fyddwch yn ffonio, bydd arnoch angen eich rhif Yswiriant Gwladol.
+
+# ---------- Not Found Section ------------------
+notFound.header=Heb ddod o hyd i’r dudalen
+notFound.explanation1=Os gwnaethoch deipio’r cyfeiriad gwe, gwiriwch ei fod yn gywir.
+notFound.explanation2=Os gwnaethoch ludo’r cyfeiriad gwe, gwiriwch eich bod wedi copïo’r cyfeiriad yn llawn.
+
+# ---------- Dummy Flag Section -----------------
+
+# ---------- Page Not Found Section -------------
+
+# ---------- Change Account Section -------------
 changeAccount.title = Caiff eich Budd-dal Plant ei dalu i’r cyfrif hwn
 changeAccount.heading = Caiff eich Budd-dal Plant ei dalu i’r cyfrif hwn
 changeAccount.subHeading = Newid y cyfrif hwn
@@ -115,11 +149,7 @@ changeAccount.table.account.number = Rhif y cyfrif:
 changeAccount.button.1 = Yn eich blaen
 changeAccount.button.2 = Peidio â newid
 
-# ------------------------- New Account Details ---------------------------
-accountNotChanged.title = Nid ydych wedi newid eich cyfrif
-accountNotChanged.heading = Nid ydych wedi newid eich cyfrif
-accountNotChanged.p1 = Byddwn yn parhau i dalu’ch Budd-dal Plant i’r un cyfrif.
-
+# ---------- Account Changed Section ------------
 accountChanged.title = Mae manylion eich cyfrif wedi’u newid
 accountChanged.heading = Mae manylion eich cyfrif wedi’u newid
 accountChanged.subHeading.1 = Yr hyn sy’n digwydd nesaf
@@ -129,6 +159,16 @@ accountChanged.paragraph.2 = Rydym yn defnyddio adborth i wella ein gwasanaethau
 accountChanged.feedback = {0}
 accountChanged.feedback.link.text = Cwblhewch yr arolwg adborth.
 
+# ---------- Account Not Changed Section --------
+accountNotChanged.title = Nid ydych wedi newid eich cyfrif
+accountNotChanged.heading = Nid ydych wedi newid eich cyfrif
+accountNotChanged.p1 = Byddwn yn parhau i dalu’ch Budd-dal Plant i’r un cyfrif.
+
+# ---------- New Account Section ----------------
+
+# ---------- BARS Lockout Section ---------------
+
+# ---------- Confirm Details Section ------------
 confirmNewAccountDetails.title = Gwirio a chadarnhau manylion eich cyfrif newydd - Budd-dal Plant
 confirmNewAccountDetails.heading = Gwirio a chadarnhau manylion eich cyfrif newydd
 confirmNewAccountDetails.subHeading = A ydych am anfon y manylion hyn atom?
@@ -141,4 +181,6 @@ confirmNewAccountDetails.checkYourAnswersLabel = A ydych am anfon y manylion hyn
 confirmNewAccountDetails.error.required = Dewiswch ‘Iawn’ neu ‘Na, hoffwn eu newid’
 confirmNewAccountDetails.change.hidden = ConfirmNewAccountDetails
 
-# ------------------------------------------------------------------------------------
+# ---------- HICBC Opted Out Section ------------
+
+# ---------- Cannot Verify Account Section ------

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -46,28 +46,28 @@ helpline.info.charges = Gwybodaeth am gostau galwadau
 helpline.info.callChargesUrl = https://www.gov.uk/costau-galwadau
 
 # ---------- Proof of Entitlement Section -------
-proofOfEntitlement.title=Tystiolaeth o hawl i Fudd-dal Plant
-proofOfEntitlement.confirmation=Cadarnhad yw hwn gan CThEF o’r hawl i Fudd-dal Plant ar gyfer {0} ar {1}.
-proofOfEntitlement.paidDetail=Caiff Budd-dal Plant ei dalu ar y cyfraddau canlynol:
-proofOfEntitlement.firstChild={0} ar gyfer y plentyn hynaf neu’r unig blentyn
-proofOfEntitlement.additionalchild={0} ar gyfer pob plentyn ychwanegol
-proofOfEntitlement.entitlementdetail.title=Manylion hawl yr hawliwr
-proofOfEntitlement.entitlementdetail.p1=Os yw’ch cyfeiriad neu unrhyw enwau’n anghywir, gallwch {0} neu am newidiadau i {1}, a byddwn yn eu diweddaru ar eich cyfer.
+proofOfEntitlement.title = Tystiolaeth o hawl i Fudd-dal Plant
+proofOfEntitlement.confirmation = Cadarnhad yw hwn gan CThEF o’r hawl i Fudd-dal Plant ar gyfer {0} ar {1}.
+proofOfEntitlement.paidDetail = Caiff Budd-dal Plant ei dalu ar y cyfraddau canlynol:
+proofOfEntitlement.firstChild = {0} ar gyfer y plentyn hynaf neu’r unig blentyn
+proofOfEntitlement.additionalchild = {0} ar gyfer pob plentyn ychwanegol
+proofOfEntitlement.entitlementdetail.title = Manylion hawl yr hawliwr
+proofOfEntitlement.entitlementdetail.p1 = Os yw’ch cyfeiriad neu unrhyw enwau’n anghywir, gallwch {0} neu am newidiadau i {1}, a byddwn yn eu diweddaru ar eich cyfer.
 proofOfEntitlement.entitlementdetail.p1.link.1 = roi gwybod i ni am newidiadau i’ch amgylchiadau
 proofOfEntitlement.entitlementdetail.p1.link.2 = amgylchiadau’ch plentyn neu’ch plant
-proofOfEntitlement.claimantname=Enw
-proofOfEntitlement.address=Cyfeiriad
-proofOfEntitlement.amount=Swm
-proofOfEntitlement.perweek={0} yr wythnos
-proofOfEntitlement.startdate=Dyddiad dechrau
-proofOfEntitlement.onorbefore=Ar neu cyn {0}
-proofOfEntitlement.enddate=Dyddiad dod i ben
-proofOfEntitlement.awardDetail=Manylion dyfarniad Budd-dal Plant ar gyfe {0}
-proofOfEntitlement.dateOfBirth=Dyddiad geni
-proofOfEntitlement.viewpayments=Bwrw golwg dros eich taliadau Budd-dal Plant
+proofOfEntitlement.claimantname = Enw
+proofOfEntitlement.address = Cyfeiriad
+proofOfEntitlement.amount = Swm
+proofOfEntitlement.perweek = {0} yr wythnos
+proofOfEntitlement.startdate = Dyddiad dechrau
+proofOfEntitlement.onorbefore = Ar neu cyn {0}
+proofOfEntitlement.enddate = Dyddiad dod i ben
+proofOfEntitlement.awardDetail = Manylion dyfarniad Budd-dal Plant ar gyfe {0}
+proofOfEntitlement.dateOfBirth = Dyddiad geni
+proofOfEntitlement.viewpayments = Bwrw golwg dros eich taliadau Budd-dal Plant
 proofOfEntitlement.viewrecentpayments.para = Gallwch {0} a gweld eich 5 dyddiad talu diwethaf a faint a dalwyd i chi.
 proofOfEntitlement.viewrecentpayments.link = fwrw golwg dros eich taliadau Budd-dal Plant diweddar
-proofOfEntitlement.printMessage=Argraffu’r dudalen hon
+proofOfEntitlement.printMessage = Argraffu’r dudalen hon
 
 # ---------- Payment History Section ------------
 paymentHistory.pageTitle = Hanes taliadau Budd-dal Plant - Budd-dal Plant - GOV.UK
@@ -82,15 +82,15 @@ paymentHistory.table.amount = Swm
 
 # ---------- No Payment History Section ---------
 # ---- Variant 2 - In payment without payments in last 2 years
-paymentHistory.v2.noReceivedPayments=Nid ydych wedi cael unrhyw daliadau yn ystod y 2 flynedd ddiwethaf.
+paymentHistory.v2.noReceivedPayments = Nid ydych wedi cael unrhyw daliadau yn ystod y 2 flynedd ddiwethaf.
 
 # ---- Variant 4 - HICBC without payments in last 2 years
-paymentHistory.v4.p1=Rydych wedi rhoi gwybod i ni nad ydych am gael eich talu oherwydd nid ydych eisiau talu’r Tâl Treth Budd-dal Plant Incwm Uchel.
-paymentHistory.v4.p2=Mae ein cofnodion yn dangos nad ydych wedi cael unrhyw daliadau yn ystod y 2 flynedd ddiwethaf.
+paymentHistory.v4.p1 = Rydych wedi rhoi gwybod i ni nad ydych am gael eich talu oherwydd nid ydych eisiau talu’r Tâl Treth Budd-dal Plant Incwm Uchel.
+paymentHistory.v4.p2 = Mae ein cofnodion yn dangos nad ydych wedi cael unrhyw daliadau yn ystod y 2 flynedd ddiwethaf.
 
 # ---- Variant 6 - Entitlement ended and no payments in last 2 years
-paymentHistory.v6.p1=Nid oes gennych hawl i gael Budd-dal Plant, mwyach.
-paymentHistory.v6.p2=Mae ein cofnodion yn dangos nad ydych wedi cael unrhyw daliadau yn ystod y 2 flynedd ddiwethaf.
+paymentHistory.v6.p1 = Nid oes gennych hawl i gael Budd-dal Plant, mwyach.
+paymentHistory.v6.p2 = Mae ein cofnodion yn dangos nad ydych wedi cael unrhyw daliadau yn ystod y 2 flynedd ddiwethaf.
 
 # ---------- Some Payment History Section -------
 # ---- Variant 1 - In payment with payments in last 2 years
@@ -101,12 +101,12 @@ paymentHistory.v1.link.text = yw’r taliad fod i gyrraedd ar ŵyl banc.
 paymentHistory.v1.p3 = Mae Budd-dal Plant yn cael ei dalu’n wythnosol, neu bob 4 wythnos. Nid yw’n cael ei dalu yn ôl misoedd calendr.
 
 # ---- Variant 3 - HICBC with payments in last 2 years
-paymentHistory.v3.p1=Rydych wedi rhoi gwybod i ni nad ydych am gael eich talu oherwydd nid ydych eisiau talu’r Tâl Treth Budd-dal Plant Incwm Uchel.
-paymentHistory.v3.p2=Mae ein cofnodion yn dangos eich bod wedi cael taliad neu daliadau yn ystod y 2 flynedd ddiwethaf.
+paymentHistory.v3.p1 = Rydych wedi rhoi gwybod i ni nad ydych am gael eich talu oherwydd nid ydych eisiau talu’r Tâl Treth Budd-dal Plant Incwm Uchel.
+paymentHistory.v3.p2 = Mae ein cofnodion yn dangos eich bod wedi cael taliad neu daliadau yn ystod y 2 flynedd ddiwethaf.
 
 # ---- Variant 5 - Entitlement ended but received payments in last 2 year
-paymentHistory.v5.p1=Nid oes gennych hawl i gael Budd-dal Plant, mwyach.
-paymentHistory.v5.p2=Mae ein cofnodion yn dangos eich bod wedi cael taliad neu daliadau yn ystod y 2 flynedd ddiwethaf.
+paymentHistory.v5.p1 = Nid oes gennych hawl i gael Budd-dal Plant, mwyach.
+paymentHistory.v5.p2 = Mae ein cofnodion yn dangos eich bod wedi cael taliad neu daliadau yn ystod y 2 flynedd ddiwethaf.
 
 # ---------- Service Unavailable Section --------
 service-unavailable-error-template.heading = Mae’n ddrwg gennym – mae problem gyda’r gwasanaeth
@@ -115,20 +115,20 @@ service-unavailable-error-template.paragraph.2 = Gallwch ein ffonio os hoffech s
 service-unavailable-error-template.paragraph.3 = Pan fyddwch yn ffonio, bydd arnoch angen eich rhif Yswiriant Gwladol.
 
 # ---------- No Account Found Section -----------
-noAccountFound.header=Nid ydych yn hawlio Budd-dal Plant
-noAccountFound.explanation=Ni allwn ddod o hyd i hawliad am Fudd-dal Plant ar eich cyfer.
-noAccountFound.reason=Gall hyn fod oherwydd:
-noAccountFound.bulletPoint1=nid ydych wedi hawlio
-noAccountFound.bulletPoint2=mae hawliad yr ydych wedi’i wneud yn dal i gael ei brosesu
-noAccountFound.bulletPoint3=cafodd yr hawliad ei wneud gan rywun arall - er enghraifft, mae’n bosibl ei fod yn enw eich partner
-noAccountFound.bulletPoint4=nid ydych yn cael Budd-dal Plant mwyach
-noAccountFound.callInfo1=Gallwch ein ffonio os oes angen gwybodaeth arnoch am hawliad sydd wedi dod i ben.
-noAccountFound.callInfo2=Pan fyddwch yn ffonio, bydd arnoch angen eich rhif Yswiriant Gwladol.
+noAccountFound.header = Nid ydych yn hawlio Budd-dal Plant
+noAccountFound.explanation = Ni allwn ddod o hyd i hawliad am Fudd-dal Plant ar eich cyfer.
+noAccountFound.reason = Gall hyn fod oherwydd:
+noAccountFound.bulletPoint1 = nid ydych wedi hawlio
+noAccountFound.bulletPoint2 = mae hawliad yr ydych wedi’i wneud yn dal i gael ei brosesu
+noAccountFound.bulletPoint3 = cafodd yr hawliad ei wneud gan rywun arall - er enghraifft, mae’n bosibl ei fod yn enw eich partner
+noAccountFound.bulletPoint4 = nid ydych yn cael Budd-dal Plant mwyach
+noAccountFound.callInfo1 = Gallwch ein ffonio os oes angen gwybodaeth arnoch am hawliad sydd wedi dod i ben.
+noAccountFound.callInfo2 = Pan fyddwch yn ffonio, bydd arnoch angen eich rhif Yswiriant Gwladol.
 
 # ---------- Not Found Section ------------------
-notFound.header=Heb ddod o hyd i’r dudalen
-notFound.explanation1=Os gwnaethoch deipio’r cyfeiriad gwe, gwiriwch ei fod yn gywir.
-notFound.explanation2=Os gwnaethoch ludo’r cyfeiriad gwe, gwiriwch eich bod wedi copïo’r cyfeiriad yn llawn.
+notFound.header = Heb ddod o hyd i’r dudalen
+notFound.explanation1 = Os gwnaethoch deipio’r cyfeiriad gwe, gwiriwch ei fod yn gywir.
+notFound.explanation2 = Os gwnaethoch ludo’r cyfeiriad gwe, gwiriwch eich bod wedi copïo’r cyfeiriad yn llawn.
 
 # ---------- Dummy Flag Section -----------------
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,3 +1,10 @@
+label.back.link=Back
+
+service.name = Child Benefit
+appName = "sca-apply-chb-frontend"
+sca-apply-chb-frontend=Apply CHB Frontend
+
+# ---------- Site Section -----------------------
 site.back = Back
 site.remove = Remove
 site.change = Change
@@ -10,15 +17,18 @@ site.signIn = Sign in
 site.govuk = GOV.UK
 site.technicalProblemMessage = Is this page not working properly? (opens in new tab)
 
+# ---------- Date Section -----------------------
 date.day = Day
 date.month = Month
 date.year = Year
 
+# ---------- Timeout Section --------------------
 timeout.title = You’re about to be signed out
 timeout.message = For security reasons, you will be signed out of this service in
 timeout.keepAlive = Stay signed in
 timeout.signOut = Sign out
 
+# ---------- Error Section ----------------------
 error.browser.title.prefix = Error:
 error.boolean = Please give an answer
 error.invalid_date = Give a correct date
@@ -34,14 +44,16 @@ error.number = Please enter a valid number
 error.required = Please enter a value
 error.summary.title = There is a problem
 
-
+# ---------- Index Section ----------------------
 index.title = child-benefit-view-frontend
 index.heading = child-benefit-view-frontend
 index.guidance = Welcome to your new frontend. Please see the README file for a guide to getting started.
 
+# ---------- Check Your Answers Section ---------
 checkYourAnswers.title = Check Your Answers
 checkYourAnswers.heading = Check Your Answers
 
+# ---------- Journey Recovery Section -----------
 journeyRecovery.continue.title = Sorry, there is a problem with the service
 journeyRecovery.continue.heading = Sorry, there is a problem with the service
 journeyRecovery.continue.guidance = [Add content to explain how to proceed.]
@@ -49,20 +61,16 @@ journeyRecovery.startAgain.title = Sorry, there is a problem with the service
 journeyRecovery.startAgain.heading = Sorry, there is a problem with the service
 journeyRecovery.startAgain.guidance = [Add content to explain why the user needs to start again.]
 
+# ---------- Signed Out Section -----------------
 signedOut.title = For your security, we signed you out
 signedOut.heading = For your security, we signed you out
 signedOut.guidance = We did not save your answers.
 
-unauthorised.title = You can’t access this service with this account
-unauthorised.heading = You can’t access this service with this account
+# ---------- Unauthorised Section ---------------
+unauthorised.title = You cannot access this service with this account
+unauthorised.heading = You cannot access this service with this account
 
-service.name = Child Benefit
-
-sca-apply-chb-frontend=Apply CHB Frontend
-appName = "sca-apply-chb-frontend"
-
-
-label.back.link=Back
+# ---------- Homepage Section -------------------
 homepage.text1=Apply for Child Benefit
 homepage.text2=You can only use this online service if:
 homepage.text3=this is your first Child Benefit application
@@ -80,7 +88,7 @@ homepage.text14=your bank or building society details
 homepage.text15=What do we mean by ’partner’?
 homepage.text16=’Partner’ means someone you’re married to and not permanently separated from, a civil partner, or someone you’re living with as if they were your civil partner.
 
-# ---------------------------- Helpline Section ----------------------------
+# ---------- Helpline Section -------------------
 helpline.info.title = Child Benefit helpline
 helpline.info.telephone = Telephone: 0300 200 3100
 helpline.info.welshTelephone = Welsh language: 0300 200 1900
@@ -90,7 +98,7 @@ helpline.info.availability = Monday to Friday, 8AM to 6PM
 helpline.info.charges = Find out about call charges
 helpline.info.callChargesUrl = https://www.gov.uk/call-charges
 
-# ---------------------------- Proof Of Entitlement ----------------------------
+# ---------- Proof of Entitlement Section -------
 proofOfEntitlement.title=Proof of entitlement to Child Benefit
 proofOfEntitlement.confirmation=This is confirmation from HMRC of the Child Benefit entitlement for {0} on {1}.
 proofOfEntitlement.paidDetail=Child Benefit is paid at:
@@ -113,10 +121,8 @@ proofOfEntitlement.viewpayments=View your Child Benefit payments
 proofOfEntitlement.viewrecentpayments.para = You can {0} and see your last 5 payment dates and how much you were paid.
 proofOfEntitlement.viewrecentpayments.link = view your recent Child Benefit payments
 proofOfEntitlement.printMessage = Print this page
-# ------------------------------------------------------------------------------------
 
-
-# ---------------------------- View Payment History ----------------------------
+# ---------- Payment History Section ------------
 paymentHistory.pageTitle = Child Benefit payment history - Child Benefit - GOV.UK
 paymentHistory.title = Child Benefit payment history
 paymentHistory.viewEntitlementProof = View proof of your entitlement to Child Benefit
@@ -127,7 +133,7 @@ paymentHistory.recentCBPayments.p1 = The 5 most recent payments made within the 
 paymentHistory.table.date = Date
 paymentHistory.table.amount = Amount
 
-# --------- No Payment History ---------
+# ---------- No Payment History Section ---------
 # ---- Variant 2 - In payment without payments in last 2 years
 paymentHistory.v2.noReceivedPayments=You have not received any payments in the last 2 years.
 
@@ -139,7 +145,7 @@ paymentHistory.v4.p2=Our records show that you have not received any payments in
 paymentHistory.v6.p1=You are no longer entitled to receive Child Benefit.
 paymentHistory.v6.p2=Our records show that you have not received any payments in the last 2 years.
 
-# --------- Some Payment History ---------
+# ---------- Some Payment History Section -------
 # ---- Variant 1 - In payment with payments in last 2 years
 paymentHistory.v1.header=Find out when you’ll be paid next
 paymentHistory.v1.p1 = If you’re paid every 4 weeks, you can find out when you’ll be paid next by counting 4 weeks forward from your last payment.
@@ -154,13 +160,14 @@ paymentHistory.v3.p2=Our records show that you have received a payment or paymen
 # ---- Variant 5 - Entitlement ended but received payments in last 2 year
 paymentHistory.v5.p1=You are no longer entitled to receive Child Benefit.
 paymentHistory.v5.p2=Our records show that you have received a payment or payments in the last 2 years.
-# ------------------------------------------------------------------------------------
 
+# ---------- Service Unavailable Section --------
 service-unavailable-error-template.heading = Sorry, there is a problem with the service
 service-unavailable-error-template.paragraph.1 = Try again later.
 service-unavailable-error-template.paragraph.2 = You can call us if you’d like to speak with someone about your Child Benefit award.
 service-unavailable-error-template.paragraph.3 = When you call, you’ll need your National Insurance number.
 
+# ---------- No Account Found Section -----------
 noAccountFound.header=You’re not claiming Child Benefit
 noAccountFound.explanation=We cannot find a Child Benefit claim for you.
 noAccountFound.reason=This might be because:
@@ -171,18 +178,21 @@ noAccountFound.bulletPoint4=you no longer receive Child Benefit
 noAccountFound.callInfo1=You can call us if you need information about a claim that has ended.
 noAccountFound.callInfo2=When you call, you’ll need your National Insurance number.
 
+# ---------- Not Found Section ------------------
 notFound.header=Page not found
 notFound.explanation1=If you typed the web address, check it’s correct.
 notFound.explanation2=If you pasted the web address, check you copied the entire address.
 
+# ---------- Dummy Flag Section -----------------
 dummyFlag.title=Dummy Flag
 dummyFlag.heading=This page will be removed
 
+# ---------- Page Not Found Section -------------
 pageNotFound.title=Page not found
 pageNotFound.heading=This page can’t be found
 pageNotFound.paragraph1=Please check that you have entered the correct web address.
 
-# ---------------------------- Change Of Bank ----------------------------
+# ---------- Change Account Section -------------
 changeAccount.title = Your Child Benefit is paid into this account
 changeAccount.heading = Your Child Benefit is paid into this account
 changeAccount.subHeading = Change this account
@@ -197,7 +207,22 @@ changeAccount.table.account.number = Account number:
 changeAccount.button.1 = Continue
 changeAccount.button.2 = Do not change
 
-# ------------------------- New Account Details ---------------------------
+# ---------- Account Changed Section ------------
+accountChanged.title = Your account details have been changed
+accountChanged.heading = Your account details have been changed
+accountChanged.subHeading.1 = What happens next
+accountChanged.paragraph.1 = HMRC will now start paying Child Benefit into your new account. However, if your next payment’s due within the next 3 working days, that will be paid into your previous account.
+accountChanged.subHeading.2 = Before you go
+accountChanged.paragraph.2 = We use feedback to make our services better.
+accountChanged.feedback = Please {0}.
+accountChanged.feedback.link.text = take the feedback survey
+
+# ---------- Account Not Changed Section --------
+accountNotChanged.title = You have not changed your account
+accountNotChanged.heading = You have not changed your account
+accountNotChanged.p1 = We’ll keep paying your Child Benefit into the same account.
+
+# ---------- New Account Section ----------------
 newAccountDetails.title = New Account Details
 newAccountDetails.heading = Tell us the new account details
 newAccountDetails.paragraph = If you want to use an account that’s not in your name, you’re responsible for making sure you get the money and that the money is used how you want.
@@ -226,25 +251,14 @@ newAccountDetails.error.bacs.priority4 = Account does not accept direct credit t
 newAccountDetails.error.bacs.priority5 = Account cannot be verified — check the account name, sort code and account number
 newAccountDetails.error.bacs.priority6 = Account name does not match account details — check account name
 
-accountChanged.title = Your account details have been changed
-accountChanged.heading = Your account details have been changed
-accountChanged.subHeading.1 = What happens next
-accountChanged.paragraph.1 = HMRC will now start paying Child Benefit into your new account. However, if your next payment’s due within the next 3 working days, that will be paid into your previous account.
-accountChanged.subHeading.2 = Before you go
-accountChanged.paragraph.2 = We use feedback to make our services better.
-accountChanged.feedback = Please {0}.
-accountChanged.feedback.link.text = take the feedback survey
-
-accountNotChanged.title = You have not changed your account
-accountNotChanged.heading = You have not changed your account
-accountNotChanged.p1 = We’ll keep paying your Child Benefit into the same account.
-
+# ---------- BARS Lockout Section ---------------
 bARSLockOut.title = You’re locked out of this service
 bARSLockOut.heading = You’re locked out of this service
 bARSLockOut.para.1 = You’re locked out because you entered details that could not be verified too many times within the last 24 hours.
 bARSLockOut.para.2 = You can {0} for your Child Benefit payments.
 bARSLockOut.link.text = use a different service to change the account details
 
+# ---------- Confirm Details Section ------------
 confirmNewAccountDetails.title = Check and confirm your new account details
 confirmNewAccountDetails.heading = Check and confirm your new account details
 confirmNewAccountDetails.subHeading = Do you want to send us these details?
@@ -257,16 +271,16 @@ confirmNewAccountDetails.checkYourAnswersLabel = Do you want to send us these de
 confirmNewAccountDetails.error.required = Select ‘Yes’ or ‘No, I want to change them’
 confirmNewAccountDetails.change.hidden = ConfirmNewAccountDetails
 
+# ---------- HICBC Opted Out Section ------------
 hICBCOptedOutPayments.title = You cannot use this service because you do not receive Child Benefit payments
 hICBCOptedOutPayments.heading = You cannot use this service because you do not receive Child Benefit payments
 hICBCOptedOutPayments.paragraph.1 = You do not receive payments because you’ve told us you do not want to pay the High Income Child Benefit Charge.
 hICBCOptedOutPayments.paragraph.2 = You can tell us if you want to {0}.
 hICBCOptedOutPayments.guide.link.text = start receiving Child Benefit payments
 
+# ---------- Cannot Verify Account Section ------
 cannotVerifyAccount.title = We cannot verify the account details you’ve provided
 cannotVerifyAccount.heading = We cannot verify the account details you’ve provided
 cannotVerifyAccount.paragraph.1 = For security, we’ve locked you out of this service for 24 hours.
 cannotVerifyAccount.paragraph.2 = You can {0} for your Child Benefit payments.
 cannotVerifyAccount.link.text = use a different service to change the account details
-
-# ------------------------------------------------------------------------------------

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -2,7 +2,7 @@ label.back.link=Back
 
 service.name = Child Benefit
 appName = "sca-apply-chb-frontend"
-sca-apply-chb-frontend=Apply CHB Frontend
+sca-apply-chb-frontend = Apply CHB Frontend
 
 # ---------- Site Section -----------------------
 site.back = Back
@@ -71,22 +71,22 @@ unauthorised.title = You cannot access this service with this account
 unauthorised.heading = You cannot access this service with this account
 
 # ---------- Homepage Section -------------------
-homepage.text1=Apply for Child Benefit
-homepage.text2=You can only use this online service if:
-homepage.text3=this is your first Child Benefit application
-homepage.text4=your child’s birth was registered in England, Scotland or Wales
-homepage.text5=you have British or Irish nationality
-homepage.text6=You can apply when your child’s birth is registered, or a child comes to live with you. You should do this as soon as possible because Child Benefit payments can only be backdated 3 months.
-homepage.text7=You can get Child Benefit if you’re legally responsible for a child who is:
-homepage.text8=is under 16
-homepage.text9=is under 20, if they are in
-homepage.text10=approved education or training
-homepage.text11=Before you start, you’ll need:
-homepage.text12=your partner’s National Insurance number, if you have a partner
-homepage.text13=the birth certificate of any child or children you’re applying for
-homepage.text14=your bank or building society details
-homepage.text15=What do we mean by ’partner’?
-homepage.text16=’Partner’ means someone you’re married to and not permanently separated from, a civil partner, or someone you’re living with as if they were your civil partner.
+homepage.text1 = Apply for Child Benefit
+homepage.text2 = You can only use this online service if:
+homepage.text3 = this is your first Child Benefit application
+homepage.text4 = your child’s birth was registered in England, Scotland or Wales
+homepage.text5 = you have British or Irish nationality
+homepage.text6 = You can apply when your child’s birth is registered, or a child comes to live with you. You should do this as soon as possible because Child Benefit payments can only be backdated 3 months.
+homepage.text7 = You can get Child Benefit if you’re legally responsible for a child who is:
+homepage.text8 = is under 16
+homepage.text9 = is under 20, if they are in
+homepage.text10 = approved education or training
+homepage.text11 = Before you start, you’ll need:
+homepage.text12 = your partner’s National Insurance number, if you have a partner
+homepage.text13 = the birth certificate of any child or children you’re applying for
+homepage.text14 = your bank or building society details
+homepage.text15 = What do we mean by ’partner’?
+homepage.text16 = ’Partner’ means someone you’re married to and not permanently separated from, a civil partner, or someone you’re living with as if they were your civil partner.
 
 # ---------- Helpline Section -------------------
 helpline.info.title = Child Benefit helpline
@@ -99,25 +99,25 @@ helpline.info.charges = Find out about call charges
 helpline.info.callChargesUrl = https://www.gov.uk/call-charges
 
 # ---------- Proof of Entitlement Section -------
-proofOfEntitlement.title=Proof of entitlement to Child Benefit
-proofOfEntitlement.confirmation=This is confirmation from HMRC of the Child Benefit entitlement for {0} on {1}.
-proofOfEntitlement.paidDetail=Child Benefit is paid at:
-proofOfEntitlement.firstChild={0} for the eldest or only child
-proofOfEntitlement.additionalchild={0} for each additional child
-proofOfEntitlement.entitlementdetail.title=Claimant’s entitlement details
-proofOfEntitlement.entitlementdetail.p1 =If your address or any names are incorrect, you can {0} or about {1} and we’ll update them for you.
+proofOfEntitlement.title = Proof of entitlement to Child Benefit
+proofOfEntitlement.confirmation = This is confirmation from HMRC of the Child Benefit entitlement for {0} on {1}.
+proofOfEntitlement.paidDetail = Child Benefit is paid at:
+proofOfEntitlement.firstChild = {0} for the eldest or only child
+proofOfEntitlement.additionalchild = {0} for each additional child
+proofOfEntitlement.entitlementdetail.title = Claimant’s entitlement details
+proofOfEntitlement.entitlementdetail.p1 = If your address or any names are incorrect, you can {0} or about {1} and we’ll update them for you.
 proofOfEntitlement.entitlementdetail.p1.link.1 = tell us about changes to your circumstances
 proofOfEntitlement.entitlementdetail.p1.link.2 = your child’s or children’s circumstances
-proofOfEntitlement.claimantname=Name
-proofOfEntitlement.address=Address
-proofOfEntitlement.amount=Amount
-proofOfEntitlement.perweek={0} per week
-proofOfEntitlement.startdate=Start date
-proofOfEntitlement.onorbefore=On or before {0}
-proofOfEntitlement.enddate=End date
-proofOfEntitlement.awardDetail=Child Benefit award details for {0}
-proofOfEntitlement.dateOfBirth=Date of birth
-proofOfEntitlement.viewpayments=View your Child Benefit payments
+proofOfEntitlement.claimantname = Name
+proofOfEntitlement.address = Address
+proofOfEntitlement.amount = Amount
+proofOfEntitlement.perweek = {0} per week
+proofOfEntitlement.startdate = Start date
+proofOfEntitlement.onorbefore = On or before {0}
+proofOfEntitlement.enddate = End date
+proofOfEntitlement.awardDetail = Child Benefit award details for {0}
+proofOfEntitlement.dateOfBirth = Date of birth
+proofOfEntitlement.viewpayments = View your Child Benefit payments
 proofOfEntitlement.viewrecentpayments.para = You can {0} and see your last 5 payment dates and how much you were paid.
 proofOfEntitlement.viewrecentpayments.link = view your recent Child Benefit payments
 proofOfEntitlement.printMessage = Print this page
@@ -135,31 +135,31 @@ paymentHistory.table.amount = Amount
 
 # ---------- No Payment History Section ---------
 # ---- Variant 2 - In payment without payments in last 2 years
-paymentHistory.v2.noReceivedPayments=You have not received any payments in the last 2 years.
+paymentHistory.v2.noReceivedPayments = You have not received any payments in the last 2 years.
 
 # ---- Variant 4 - HICBC without payments in last 2 years
-paymentHistory.v4.p1=You have told us you do not want payments because you do not want to pay the High Income Child Benefit Charge.
-paymentHistory.v4.p2=Our records show that you have not received any payments in the last 2 years.
+paymentHistory.v4.p1 = You have told us you do not want payments because you do not want to pay the High Income Child Benefit Charge.
+paymentHistory.v4.p2 = Our records show that you have not received any payments in the last 2 years.
 
 # ---- Variant 6 - Entitlement ended and no payments in last 2 years
-paymentHistory.v6.p1=You are no longer entitled to receive Child Benefit.
-paymentHistory.v6.p2=Our records show that you have not received any payments in the last 2 years.
+paymentHistory.v6.p1 = You are no longer entitled to receive Child Benefit.
+paymentHistory.v6.p2 = Our records show that you have not received any payments in the last 2 years.
 
 # ---------- Some Payment History Section -------
 # ---- Variant 1 - In payment with payments in last 2 years
-paymentHistory.v1.header=Find out when you’ll be paid next
+paymentHistory.v1.header = Find out when you’ll be paid next
 paymentHistory.v1.p1 = If you’re paid every 4 weeks, you can find out when you’ll be paid next by counting 4 weeks forward from your last payment.
 paymentHistory.v1.p2 = You’ll be paid earlier if {0}
 paymentHistory.v1.link.text = the payment’s due on a bank holiday.
 paymentHistory.v1.p3 = Child Benefit is paid weekly or every 4 weeks. It is not paid by calendar month.
 
 # ---- Variant 3 - HICBC with payments in last 2 years
-paymentHistory.v3.p1=You have told us you do not want payments because you do not want to pay the High Income Child Benefit Charge.
-paymentHistory.v3.p2=Our records show that you have received a payment or payments in the last 2 years.
+paymentHistory.v3.p1 = You have told us you do not want payments because you do not want to pay the High Income Child Benefit Charge.
+paymentHistory.v3.p2 = Our records show that you have received a payment or payments in the last 2 years.
 
 # ---- Variant 5 - Entitlement ended but received payments in last 2 year
-paymentHistory.v5.p1=You are no longer entitled to receive Child Benefit.
-paymentHistory.v5.p2=Our records show that you have received a payment or payments in the last 2 years.
+paymentHistory.v5.p1 = You are no longer entitled to receive Child Benefit.
+paymentHistory.v5.p2 = Our records show that you have received a payment or payments in the last 2 years.
 
 # ---------- Service Unavailable Section --------
 service-unavailable-error-template.heading = Sorry, there is a problem with the service
@@ -168,29 +168,29 @@ service-unavailable-error-template.paragraph.2 = You can call us if you’d like
 service-unavailable-error-template.paragraph.3 = When you call, you’ll need your National Insurance number.
 
 # ---------- No Account Found Section -----------
-noAccountFound.header=You’re not claiming Child Benefit
-noAccountFound.explanation=We cannot find a Child Benefit claim for you.
-noAccountFound.reason=This might be because:
-noAccountFound.bulletPoint1=you’ve not made a claim
-noAccountFound.bulletPoint2=a claim you’ve made is still being processed
-noAccountFound.bulletPoint3=someone else made the claim – for example, it may be in your partner’s name
-noAccountFound.bulletPoint4=you no longer receive Child Benefit
-noAccountFound.callInfo1=You can call us if you need information about a claim that has ended.
-noAccountFound.callInfo2=When you call, you’ll need your National Insurance number.
+noAccountFound.header = You’re not claiming Child Benefit
+noAccountFound.explanation = We cannot find a Child Benefit claim for you.
+noAccountFound.reason = This might be because:
+noAccountFound.bulletPoint1 = you’ve not made a claim
+noAccountFound.bulletPoint2 = a claim you’ve made is still being processed
+noAccountFound.bulletPoint3 = someone else made the claim – for example, it may be in your partner’s name
+noAccountFound.bulletPoint4 = you no longer receive Child Benefit
+noAccountFound.callInfo1 = You can call us if you need information about a claim that has ended.
+noAccountFound.callInfo2 = When you call, you’ll need your National Insurance number.
 
 # ---------- Not Found Section ------------------
-notFound.header=Page not found
-notFound.explanation1=If you typed the web address, check it’s correct.
-notFound.explanation2=If you pasted the web address, check you copied the entire address.
+notFound.header = Page not found
+notFound.explanation1 = If you typed the web address, check it’s correct.
+notFound.explanation2 = If you pasted the web address, check you copied the entire address.
 
 # ---------- Dummy Flag Section -----------------
-dummyFlag.title=Dummy Flag
-dummyFlag.heading=This page will be removed
+dummyFlag.title = Dummy Flag
+dummyFlag.heading = This page will be removed
 
 # ---------- Page Not Found Section -------------
-pageNotFound.title=Page not found
-pageNotFound.heading=This page can’t be found
-pageNotFound.paragraph1=Please check that you have entered the correct web address.
+pageNotFound.title = Page not found
+pageNotFound.heading = This page can’t be found
+pageNotFound.paragraph1 = Please check that you have entered the correct web address.
 
 # ---------- Change Account Section -------------
 changeAccount.title = Your Child Benefit is paid into this account


### PR DESCRIPTION
[SB-1326](https://jira.tools.tax.service.gov.uk/browse/SB-1326)
Rearrange message files for comparability. Add immediately required Welsh messages.

- Change the HMRC Timeout Dialog to use the HMRC Timeout Dialog Helper: this collects some other data including the current language to correctly translate the "minutes" and "seconds" which is handled internally.
- Add missing Welsh translations that we require.
- Remove unused unauthorised.guidance paragraph from the unauthorised view.
- Rearrange the english and welsh message files to all contain the same section block titles in the same order. This will make our upcoming comparison of what is unavailable in welsh.