### PR TITLE
SB-1286 - Ensure features have their own allowlist config

### DIFF
--- a/app/config/FeatureAllowlistFilter.scala
+++ b/app/config/FeatureAllowlistFilter.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import com.google.inject.Inject
+import play.api.Configuration
+import play.api.mvc.Results.{Forbidden, Redirect}
+import play.api.mvc.{Call, RequestHeader, Result}
+
+import scala.concurrent.Future
+
+class FeatureAllowlistFilter @Inject() (config: Configuration) {
+
+  val trueClient = "True-Client-IP"
+
+  val allowlist: String => Seq[String] = (feature: String) =>
+    config
+      .get[String](s"feature-allowlist.$feature.ips")
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
+  val destination: Call = {
+    val path = config.get[String]("feature-allowlist.destination")
+    Call("GET", path)
+  }
+
+  val noHeaderAction: Future[Result] =
+    Future.successful(Redirect(destination))
+
+  def response: Result = Redirect(destination)
+
+  def apply(f: RequestHeader => Future[Result])(feature: String, rh: RequestHeader): Future[Result] =
+    if (config.get[Boolean](s"feature-allowlist.$feature.enabled")) {
+      rh.headers
+        .get(trueClient)
+        .fold(noHeaderAction)(ip =>
+          if (allowlist(feature).contains(ip))
+            f(rh)
+          else if (rh.uri == destination.url)
+            Future.successful(Forbidden)
+          else
+            Future.successful(response)
+        )
+    } else {
+      f(rh)
+    }
+}

--- a/app/controllers/DummyFlagController.scala
+++ b/app/controllers/DummyFlagController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import controllers.actions.FeatureFlagActionFactory
-import play.api.{Configuration, Logging}
+import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -29,16 +29,12 @@ import scala.concurrent.Future
 class DummyFlagController @Inject() (
     val controllerComponents: MessagesControllerComponents,
     view:                     DummyFlagView,
-    featureFlags:             FeatureFlagActionFactory,
-    configuration:            Configuration
+    featureFlags:             FeatureFlagActionFactory
 ) extends FrontendBaseController
     with I18nSupport
     with Logging {
   val onPageLoad: Action[AnyContent] =
     (Action andThen featureFlags.dummyFlagEnabled).async { implicit request =>
-      val featureFlags: Map[String, Boolean] = configuration.get[Map[String, Boolean]]("feature-flags")
-      val log = featureFlags.mkString("Features state: ", ", ", "")
-      logger.info(log)
       Future.successful(Ok(view()))
     }
 }

--- a/app/controllers/PaymentHistoryController.scala
+++ b/app/controllers/PaymentHistoryController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import config.FrontendAppConfig
+import controllers.actions.AllowlistAction
 import utils.handlers.ErrorHandler
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import play.api.{Configuration, Environment}
@@ -29,7 +30,8 @@ import scala.concurrent.ExecutionContext
 class PaymentHistoryController @Inject() (
     authConnector:         AuthConnector,
     paymentHistoryService: PaymentHistoryService,
-    errorHandler:          ErrorHandler
+    errorHandler:          ErrorHandler,
+    allowlistAction:       AllowlistAction
 )(implicit
     config:            Configuration,
     env:               Environment,
@@ -39,7 +41,7 @@ class PaymentHistoryController @Inject() (
     auditService:      AuditService
 ) extends ChildBenefitBaseController(authConnector) {
   val view: Action[AnyContent] =
-    Action.async { implicit request =>
+    (Action andThen allowlistAction).async { implicit request =>
       authorisedAsChildBenefitUser { implicit authContext =>
         paymentHistoryService.retrieveAndValidatePaymentHistory.fold(
           err => errorHandler.handleError(err, Some("paymentDetails")),

--- a/app/controllers/ProofOfEntitlementController.scala
+++ b/app/controllers/ProofOfEntitlementController.scala
@@ -18,6 +18,7 @@ package controllers
 
 import config.FrontendAppConfig
 import connectors.ChildBenefitEntitlementConnector
+import controllers.actions.AllowlistAction
 import utils.handlers.ErrorHandler
 import play.api.i18n.Messages
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -37,7 +38,8 @@ class ProofOfEntitlementController @Inject() (
     authConnector:                    AuthConnector,
     childBenefitEntitlementConnector: ChildBenefitEntitlementConnector,
     errorHandler:                     ErrorHandler,
-    proofOfEntitlement:               ProofOfEntitlement
+    proofOfEntitlement:               ProofOfEntitlement,
+    allowlistAction:                  AllowlistAction
 )(implicit
     config:            Configuration,
     env:               Environment,
@@ -47,7 +49,7 @@ class ProofOfEntitlementController @Inject() (
     auditor:           AuditService
 ) extends ChildBenefitBaseController(authConnector) {
   val view: Action[AnyContent] =
-    Action.async { implicit request =>
+    (Action andThen allowlistAction).async { implicit request =>
       authorisedAsChildBenefitUser { authContext =>
         childBenefitEntitlementConnector.getChildBenefitEntitlement.fold(
           err => errorHandler.handleError(err, Some("proofOfEntitlement")),

--- a/app/controllers/actions/AllowlistAction.scala
+++ b/app/controllers/actions/AllowlistAction.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import config.AllowlistFilter
+
+import javax.inject.Inject
+import play.api.mvc.{ActionFunction, Request, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AllowlistAction @Inject() (
+    val allowList:               AllowlistFilter
+)(implicit val executionContext: ExecutionContext)
+    extends ActionFunction[Request, Request] {
+  override def invokeBlock[A](request: Request[A], block: Request[A] => Future[Result]): Future[Result] =
+    allowList(_ => block(request))(request)
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -132,39 +132,50 @@ features {
 }
 
 feature-flags {
-  dummy-flag = true
-  change-of-bank = true
-  ftnae = true
-  add-child = true
-  hicbc = true
+
+  dummy-flag {
+    enabled = true
+    allowlist {
+        enabled = false
+        destination = "https://www.tax.service.gov.uk/"
+        ips = ""
+    }
+  }
+  change-of-bank {
+    enabled = true
+    allowlist {
+        enabled = false
+        destination = "https://www.tax.service.gov.uk/"
+        ips = ""
+    }
+  }
+  ftnae {
+    enabled = true
+    allowlist {
+        enabled = false
+        destination = "https://www.tax.service.gov.uk/"
+        ips = ""
+    }
+  }
+  add-child {
+    enabled = true
+    allowlist {
+        enabled = false
+        destination = "https://www.tax.service.gov.uk/"
+        ips = ""
+    }
+  }
+  hicbc {
+    enabled = true
+    allowlist {
+        enabled = false
+        destination = "https://www.tax.service.gov.uk/"
+        ips = ""
+    }
+  }
 }
 
 accessibility-statement.service-path = "/child-benefit"
-
-feature-allowlist {
-    destination = "https://www.tax.service.gov.uk/"
-
-    dummy-flag {
-      enabled = false
-      ips = ""
-     }
-    change-of-bank {
-      enabled = false
-      ips = ""
-     }
-    ftnae {
-      enabled = false
-      ips = ""
-     }
-    add-child {
-      enabled = false
-      ips = ""
-     }
-    hicbc {
-      enabled = false
-      ips = ""
-     }
-  }
 
 bootstrap {
   filters {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,6 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "utils.handlers.ErrorHandler"
 
 play.filters.enabled += "play.filters.csp.CSPFilter"
-play.filters.enabled += "config.AllowlistFilter"
 
 play.filters.csp {
     directives = {
@@ -141,6 +140,31 @@ feature-flags {
 }
 
 accessibility-statement.service-path = "/child-benefit"
+
+feature-allowlist {
+    destination = "https://www.tax.service.gov.uk/"
+
+    dummy-flag {
+      enabled = false
+      ips = ""
+     }
+    change-of-bank {
+      enabled = false
+      ips = ""
+     }
+    ftnae {
+      enabled = false
+      ips = ""
+     }
+    add-child {
+      enabled = false
+      ips = ""
+     }
+    hicbc {
+      enabled = false
+      ips = ""
+     }
+  }
 
 bootstrap {
   filters {

--- a/test-utils/testconfig/TestConfig.scala
+++ b/test-utils/testconfig/TestConfig.scala
@@ -36,7 +36,7 @@ object TestConfig {
 
   implicit class TestConfigExtensions(config: Map[String, Any]) {
     def withFeatureFlags(featureFlags: Map[String, Boolean]): Map[String, Any] = {
-      val featureFlagMap = ("feature-flags", featureFlags.map(f => (f._1, f._2.toString)))
+      val featureFlagMap = ("feature-flags", featureFlags.map(f => (s"${f._1}.enabled", f._2.toString)))
       config + featureFlagMap
     }
   }

--- a/test/controllers/DummyFlagControllerSpec.scala
+++ b/test/controllers/DummyFlagControllerSpec.scala
@@ -27,7 +27,7 @@ import views.html.{DummyFlagView, ErrorTemplate}
 class DummyFlagControllerSpec extends BaseISpec with EitherValues {
   "Dummy flag controller" - {
     "must render the correct view when flag is enabled" in {
-      val application = applicationBuilder().build()
+      val application = applicationBuilder(config = Map("feature-flags.dummy-flag.enabled" -> true)).build()
 
       running(application) {
         implicit val request: FakeRequest[AnyContentAsEmpty.type] =
@@ -46,7 +46,7 @@ class DummyFlagControllerSpec extends BaseISpec with EitherValues {
     }
 
     "must fail with 404 when flag is disabled" in {
-      val application = applicationBuilder(config = Map("feature-flags.dummy-flag" -> false)).build()
+      val application = applicationBuilder(config = Map("feature-flags.dummy-flag.enabled" -> false)).build()
 
       running(application) {
         implicit val request: FakeRequest[AnyContentAsEmpty.type] =


### PR DESCRIPTION
This has been updated to have an allow list filter for each feature independently. This means each feature can define its own list of ips. For the features this has been applied to the `FeatureFlagActionFactory`

To keep the current behaviour for view proof of entitlement and payment history I have applied an independent `AllowlistAction`