### PR TITLE
Resolve unhandled exception in ErrorHandler fireAuditEvent

### DIFF
--- a/app/utils/handlers/ErrorHandler.scala
+++ b/app/utils/handlers/ErrorHandler.scala
@@ -22,7 +22,7 @@ import play.api.Logging
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.Results.Redirect
-import play.api.mvc.{AnyContent, MessagesRequest, Request, Result}
+import play.api.mvc.{Request, Result}
 import play.twirl.api.Html
 import services.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -37,7 +37,7 @@ class ErrorHandler @Inject() (
     val messagesApi: MessagesApi,
     notFoundView:    NotFoundView,
     error:           ErrorTemplate
-)() extends FrontendErrorHandler
+) extends FrontendErrorHandler
     with I18nSupport
     with Logging {
 
@@ -83,19 +83,20 @@ class ErrorHandler @Inject() (
       hc:                                 HeaderCarrier,
       ec:                                 ExecutionContext
   ): Unit = {
-    if (auditOrigin.contains("proofOfEntitlement"))
+    if (auditOrigin.contains("proofOfEntitlement")) {
       auditService.auditProofOfEntitlement(
         "Unknown",
         "No Accounts Found",
-        request.asInstanceOf[MessagesRequest[AnyContent]],
+        request,
         None
       )
-    else if (auditOrigin.contains("paymentDetails"))
+    } else if (auditOrigin.contains("paymentDetails")) {
       auditService.auditPaymentDetails(
         "nino",
         "No Accounts Found",
         request,
         None
       )
+    }
   }
 }


### PR DESCRIPTION
Rely on inheritance of Request no that authcontext is not in use when…… auditing error handling

History:
The proof of entitlement path used to make use of the no defunct AuthContext, an object created with auth details on the current user. This had no inheritance relationship with Request[_] that is required for raising audits.
The cast to MessagesRequest[AnyContext] was specifically marshalled to over come this.
Now we make use of the IdentifierRequest which contains both the info that AuthContext used to and is still a super class of Request so this just meets the requirements.

Remove the asInstanceOf and this is what was throwing the exception and is no longer required.

Unit Tests for ErrorHandler and been atomised and expanded to check this still behaves.