### PR TITLE
Remove erroneous comma that is being flagged in accessibility tests

### DIFF
--- a/app/views/cob/ChangeAccountView.scala.html
+++ b/app/views/cob/ChangeAccountView.scala.html
@@ -96,7 +96,7 @@
 
     @para(messages("changeAccount.paragraph.1"))
 
-    <div class="govuk-warning-text", id="warning-text">
+    <div class="govuk-warning-text" id="warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
             <span class="govuk-warning-text__assistive">Warning</span>


### PR DESCRIPTION
[SB-1481](https://jira.tools.tax.service.gov.uk/browse/SB-1481)

A small error that does not affect the resulting HTML but is being picked up by our new accessibility testing job so resolving it.