### PR TITLE
Remove generated title text from title message to remove duplication

### DIFF
--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -372,7 +372,7 @@ notEntitledCourseEmployerProvided.heading = Nid oes gennych hawl i barhau i gael
 notEntitledCourseEmployerProvided.p1 = Ni fydd y swyddfa Budd-dal Plant yn ymestyn taliadau os yw cwrs person ifanc yn cael ei ddarparu gan ei gyflogwr.
 
 # ----------  FTNAE check your answers ------------
-checkYourAnswers.title = Gwiriwch eich atebion cyn eu hanfon - Budd-dal Plant
+checkYourAnswers.title = Gwiriwch eich atebion cyn eu hanfon
 checkYourAnswers.heading = Gwiriwch eich atebion cyn eu hanfon
 checkYourAnswers.h2 = Anfonwch eich atebion nawr
 checkYourAnswers.warning = Mae’n rhaid bod yr wybodaeth hon yn gywir, hyd eithaf eich gwybodaeth.


### PR DESCRIPTION
[[SB-1338]](https://jira.tools.tax.service.gov.uk/browse/SB-1338)

Budd-dal Plant (Welsh for Child Benefit) is added to all page title's automatically (as well as GOV.UK), it is not required in the title text and is thus being currently being duplicated.