### PR TITLE
SB-1632: Unique ids for link on CannotFindYoungPerson view

### DIFF
--- a/app/views/ftnae/CannotFindYoungPersonView.scala.html
+++ b/app/views/ftnae/CannotFindYoungPersonView.scala.html
@@ -33,13 +33,13 @@
         newTab = false
     )}
 
-    @viewAlreadyInformedLink = @{link( id = "view-entitlement",
+    @viewAlreadyInformedLink = @{link( id = "view-entitlement-already-informed",
         text = messages("cannotFindYoungPerson.p2.linkText"),
         call = Call("GET", messages("whichYoungPerson.formlink.ch297")),
         newTab = false
     )}
 
-    @viewEntitlementsToStopLink = @{link( id = "view-entitlement",
+    @viewEntitlementsToStopLink = @{link( id = "view-entitlement-to-stop",
         text = messages("cannotFindYoungPerson.p3.linkText"),
         call = Call("GET", routes.ProofOfEntitlementController.view.url),
         newTab = false


### PR DESCRIPTION
[[SB-1632]](https://jira.tools.tax.service.gov.uk/browse/SB-1632)

Accessibility issue spotted during testing of SB-1632, two links with non unique ids. Ids made unique to better support accessibility tools.