### PR TITLE
SB-1655: Clear user's session after successful CoB submission

### DIFF
--- a/app/controllers/cob/ConfirmNewAccountDetailsController.scala
+++ b/app/controllers/cob/ConfirmNewAccountDetailsController.scala
@@ -108,7 +108,8 @@ class ConfirmNewAccountDetailsController @Inject() (
                     submitClaimant <-
                       changeOfBankService
                         .submitClaimantChangeOfBank(
-                          changeAccount
+                          changeAccount,
+                          request
                         )
                         .value
                   } yield {

--- a/app/services/ChangeOfBankService.scala
+++ b/app/services/ChangeOfBankService.scala
@@ -41,7 +41,7 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class ChangeOfBankService @Inject() (
     changeOfBankConnector: ChangeOfBankConnector,
-    sessionRepository: SessionRepository
+    sessionRepository:     SessionRepository
 )(implicit auditService:   AuditService) {
 
   def retrieveBankClaimantInfo(implicit
@@ -90,7 +90,7 @@ class ChangeOfBankService @Inject() (
 
   def submitClaimantChangeOfBank(
       newBankAccountInfo: Option[NewAccountDetails],
-      request: BaseDataRequest[AnyContent]
+      request:            BaseDataRequest[AnyContent]
   )(implicit
       ec: ExecutionContext,
       hc: HeaderCarrier

--- a/app/views/cob/AccountChangedView.scala.html
+++ b/app/views/cob/AccountChangedView.scala.html
@@ -35,7 +35,7 @@
                         call = Call("GET", config.exitSurveyUrl)
                         )}
 
-@layout(pageTitle = titleNoForm(messages("accountChanged.title"))) {
+@layout(pageTitle = titleNoForm(messages("accountChanged.title")), showBackLink = false) {
 
     @panel(messages("accountChanged.heading"))
 

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -29,17 +29,20 @@ import java.time.LocalDate
 
 trait ModelGenerators {
 
-  implicit lazy val arbitraryHowManyYears: Arbitrary[HowManyYears] =
+  implicit lazy val arbitraryHowManyYears: Arbitrary[HowManyYears] = {
     Arbitrary {
       Gen.oneOf(HowManyYears.values.toSeq)
     }
-  private val ALLOWED_SORT_CODE_LENGTH = 6
+  }
+  private val ACCOUNT_HOLDER_MAX_LENGTH     = 30
+  private val ALLOWED_SORT_CODE_LENGTH      = 6
+  private val ALLOWED_ACCOUNT_NUMBER_LENGTH = 8
   implicit lazy val arbitraryNewAccountDetails: Arbitrary[NewAccountDetails] =
     Arbitrary {
       for {
-        accountHolder <- arbitrary[String]
-        sortCode      <- arbitrary[String].map(_.take(ALLOWED_SORT_CODE_LENGTH))
-        accountNumber <- arbitrary[String]
+        accountHolder <- alphaStr.suchThat(_.length > 0).map(_.take(ACCOUNT_HOLDER_MAX_LENGTH))
+        sortCode      <- numStr.map(_.take(ALLOWED_SORT_CODE_LENGTH))
+        accountNumber <- numStr.map(_.take(ALLOWED_ACCOUNT_NUMBER_LENGTH))
       } yield NewAccountDetails(accountHolder, sortCode, accountNumber)
     }
   implicit lazy val arbitraryConfirmNewAccountDetails: Arbitrary[ConfirmNewAccountDetails] =
@@ -202,4 +205,10 @@ trait ModelGenerators {
       ClaimantBankAccountInformation(None, None, None, None)
     }
 
+  val generateId: Arbitrary[String] =
+    Arbitrary {
+      for {
+        id <- alphaNumStr.suchThat(_.length >= 25).map(_.take(25))
+      } yield id
+    }
 }

--- a/test/controllers/cob/AccountChangedControllerSpec.scala
+++ b/test/controllers/cob/AccountChangedControllerSpec.scala
@@ -26,6 +26,7 @@ import play.api.Application
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import repositories.SessionRepository
 import services.{AuditService, ChangeOfBankService}
 import testconfig.TestConfig
 import testconfig.TestConfig._
@@ -42,9 +43,10 @@ import scala.concurrent.ExecutionContext
 class AccountChangedControllerSpec extends BaseISpec with MockitoSugar with ScalaCheckPropertyChecks {
 
   val mockCobConnector          = mock[ChangeOfBankConnector]
+  val mockSessionRepository     = mock[SessionRepository]
   implicit val mockAuditService = mock[AuditService]
 
-  val cobService: ChangeOfBankService = new ChangeOfBankService(mockCobConnector) {
+  val cobService: ChangeOfBankService = new ChangeOfBankService(mockCobConnector, mockSessionRepository) {
 
     override def dropChangeOfBankCache()(implicit ec: ExecutionContext, hc: HeaderCarrier): CBEnvelope[Unit] = {
       CBEnvelope(())

--- a/test/controllers/cob/ConfirmNewAccountDetailsControllerSpec.scala
+++ b/test/controllers/cob/ConfirmNewAccountDetailsControllerSpec.scala
@@ -23,6 +23,7 @@ import models.CBEnvelope.CBEnvelope
 import models.changeofbank.ClaimantBankInformation
 import models.cob.ConfirmNewAccountDetails.Yes
 import models.cob.{ConfirmNewAccountDetails, NewAccountDetails, UpdateBankDetailsResponse}
+import models.requests.BaseDataRequest
 import models.{CBEnvelope, NormalMode, UserAnswers}
 import org.mockito.Mockito.reset
 import org.mockito.MockitoSugar.when
@@ -32,7 +33,7 @@ import pages.cob.{ConfirmNewAccountDetailsPage, NewAccountDetailsPage}
 import play.api.Application
 import play.api.data.Form
 import play.api.inject.bind
-import play.api.mvc.Call
+import play.api.mvc.{AnyContent, Call}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.SessionRepository
@@ -68,14 +69,15 @@ class ConfirmNewAccountDetailsControllerSpec extends BaseISpec with MockitoSugar
   val formProvider = new ConfirmNewAccountDetailsFormProvider()
   val form: Form[ConfirmNewAccountDetails] = formProvider()
 
-  val cobService: ChangeOfBankService = new ChangeOfBankService(mockCobConnector) {
+  val cobService: ChangeOfBankService = new ChangeOfBankService(mockCobConnector, mockSessionRepository) {
     override def retrieveBankClaimantInfo(implicit
         ec: ExecutionContext,
         hc: HeaderCarrier
     ): CBEnvelope[ClaimantBankInformation] = CBEnvelope(claimantBankInformation)
 
     override def submitClaimantChangeOfBank(
-        newBankAccountInfo: Option[NewAccountDetails]
+        newBankAccountInfo: Option[NewAccountDetails],
+        request: BaseDataRequest[AnyContent]
     )(implicit
         ec: ExecutionContext,
         hc: HeaderCarrier

--- a/test/controllers/cob/ConfirmNewAccountDetailsControllerSpec.scala
+++ b/test/controllers/cob/ConfirmNewAccountDetailsControllerSpec.scala
@@ -77,7 +77,7 @@ class ConfirmNewAccountDetailsControllerSpec extends BaseISpec with MockitoSugar
 
     override def submitClaimantChangeOfBank(
         newBankAccountInfo: Option[NewAccountDetails],
-        request: BaseDataRequest[AnyContent]
+        request:            BaseDataRequest[AnyContent]
     )(implicit
         ec: ExecutionContext,
         hc: HeaderCarrier

--- a/test/services/ChangeOfBankServiceSpec.scala
+++ b/test/services/ChangeOfBankServiceSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import cats.implicits.catsSyntaxEitherId
+import connectors.ChangeOfBankConnector
+import generators.ModelGenerators
+import models.{CBEnvelope, UserAnswers}
+import models.cob.{NewAccountDetails, UpdateBankAccountRequest, UpdateBankDetailsResponse}
+import models.errors.CBError
+import models.requests.DataRequest
+import org.mockito.ArgumentMatchers.any
+import org.mockito.MockitoSugar.{verify, when}
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.forAll
+import play.api.mvc.AnyContent
+import play.api.test.FakeRequest
+import repositories.SessionRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ChangeOfBankServiceSpec extends PlaySpec with MockitoSugar with ScalaFutures with ModelGenerators {
+  val cobConnector          = mock[ChangeOfBankConnector]
+  val sessionRepository     = mock[SessionRepository]
+  implicit val auditService = mock[AuditService]
+  implicit val ec           = scala.concurrent.ExecutionContext.Implicits.global
+  implicit val hc           = HeaderCarrier()
+
+  val sut = new ChangeOfBankService(cobConnector, sessionRepository)
+
+  "ChangeOfBankService" should {
+    "submitClaimantChangeOfBank" should {
+      "GIVEN a valid NewAccountDetails, Id and UserAnwers" should {
+        "WHEN the ChangeOfBankConnector returns a successful response" should {
+          val expectedResponse = UpdateBankDetailsResponse("UNIT_TEST_STATUS")
+          when(cobConnector.updateBankAccount(any[UpdateBankAccountRequest])(any[ExecutionContext], any[HeaderCarrier]))
+            .thenReturn(CBEnvelope(expectedResponse))
+          when(sessionRepository.clear(any[String]))
+            .thenReturn(Future.successful(true))
+
+          forAll((arbitrary[NewAccountDetails], "accountDetails"), (arbitrary[String](generateId), "id")) {
+            (accountDetails, id) =>
+              val request: DataRequest[AnyContent] = DataRequest(FakeRequest(), id, UserAnswers(id))
+              whenReady(sut.submitClaimantChangeOfBank(Some(accountDetails), request)(ec, hc).value) { response =>
+                s"Id: $id" should {
+                  s"THEN the expected UpdateBankDetailsResponse is returned - Id: $id" in {
+                    response mustBe expectedResponse.asRight[CBError]
+                  }
+                  s"AND a call is made to clear the user's session - Id: $id" in {
+                    verify(sessionRepository).clear(id)
+                  }
+                }
+              }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/services/ChangeOfBankServiceSpec.scala
+++ b/test/services/ChangeOfBankServiceSpec.scala
@@ -1,3 +1,0 @@
-package services class ChangeOfBankServiceSpec {
-
-}

--- a/test/services/ChangeOfBankServiceSpec.scala
+++ b/test/services/ChangeOfBankServiceSpec.scala
@@ -1,0 +1,3 @@
+package services class ChangeOfBankServiceSpec {
+
+}


### PR DESCRIPTION
[[SB-1655]](https://jira.tools.tax.service.gov.uk/browse/SB-1655)

Clear user's session on successful CoB submission and remove back link from the AccoundChangedView
Subsequent work will be raised to investigate adding functionality to the JourneyRecovery system should anyone fall outside of this.