### PR TITLE
[SB-1661] Structural fixes to the Which Young Person Page

### DIFF
--- a/app/models/viewmodels/govuk/FieldsetFluency.scala
+++ b/app/models/viewmodels/govuk/FieldsetFluency.scala
@@ -79,6 +79,11 @@ trait FieldsetFluency {
         .withCssClass(size.toString)
         .withCssClass("govuk-fieldset__legend-as-header")
 
+    def asFieldSetHeading(size: LegendSize = LegendSize.ExtraLarge): Legend =
+      legend
+        .copy()
+        .withCssClass(size.toString)
+
     def withCssClass(newClass: String): Legend =
       legend copy (classes = s"${legend.classes} $newClass")
   }

--- a/app/views/ftnae/WhichYoungPersonView.scala.html
+++ b/app/views/ftnae/WhichYoungPersonView.scala.html
@@ -38,7 +38,7 @@
     @if(form.errors.nonEmpty) {
         @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value_0")))
     }
-    @heading(messages("whichYoungPerson.heading"))
+    @heading(messages("whichYoungPerson.heading"), "govuk-heading-l")
     @para(messages("whichYoungPerson.p1"))
 
     @for(child <- ftneaResponse.children) {
@@ -60,7 +60,7 @@
         @govukRadios(
             RadiosViewModel(
                 field = form("value"),
-                legend = LegendViewModel(messages("whichYoungPerson.radioLegend")).asPageHeading(size = LegendSize.Medium),
+                legend = LegendViewModel(messages("whichYoungPerson.radioLegend")).asFieldSetHeading(size = LegendSize.Medium),
                 items = getRadioItems(messages("whichYoungPerson.childNotListed"))
             )
         )


### PR DESCRIPTION
[[SB-1661]](https://jira.tools.tax.service.gov.uk/browse/SB-1661)

Add new Legend Fluency to avoid non page heading legends being set to contain a h1.
This was something we have been missing as all previous legends have also been page headings.