### PR TITLE
SB-1662 Remove floating langauge select

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,7 +28,3 @@ body:not(.js-enabled) {
 .govuk-back-link {
     margin-top: 40px;
 }
-
-.hmrc-language-select {
-    float: right;
-}


### PR DESCRIPTION
Here's the layout problem with the confirmation: 
<img width="421" alt="Screenshot 2023-06-06 at 05 01 30" src="https://github.com/hmrc/child-benefit-view-frontend/assets/10521622/4e016fa3-a8da-428a-bfe4-01e494cfe0e9">

Here's the layout with the floating class removed:
<img width="424" alt="Screenshot 2023-06-06 at 05 06 24" src="https://github.com/hmrc/child-benefit-view-frontend/assets/10521622/c1406c4d-67d8-4bf5-8934-35dda02e6a88">

And on desktop:
<img width="1039" alt="Screenshot 2023-06-06 at 05 06 38" src="https://github.com/hmrc/child-benefit-view-frontend/assets/10521622/e17be5ea-9470-4676-a5cc-f40320faa97b">


