### PR TITLE
Add missing message

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -305,6 +305,7 @@ extendPayments.p4.linkText = if their circumstances will be different
 whichYoungPerson.title = Who do you want to tell the Child Benefit office about?
 whichYoungPerson.heading = Who do you want to tell the Child Benefit office about?
 whichYoungPerson.p1 = If you want to tell us about more than one young person, complete a separate declaration for each one.
+whichYoungPerson.radioLegend = Select young person’s name
 whichYoungPerson.childNotListed = Young person not listed
 whichYoungPerson.error.required = Select a young person’s name or Young person not listed.
 whichYoungPerson.checkYourAnswersLabel = Who do you want to tell the Child Benefit office about?


### PR DESCRIPTION
[SB-1661](https://github.com/hmrc/child-benefit-view-frontend/pull/230/files) added a message for a legend - this got removed in main somehow. Possibly there was a conflict in the messages file during a merge? This PR adds it back in.