### PR TITLE
[SB-1599] Links as Buttons give a role

### DIFF
--- a/app/views/cob/ChangeAccountView.scala.html
+++ b/app/views/cob/ChangeAccountView.scala.html
@@ -27,6 +27,7 @@
         para: ParagraphBody,
         govukSummaryList: GovukSummaryList,
         link: Link,
+        buttonLink: ButtonLink,
         note: Notification
 )
 
@@ -41,34 +42,29 @@
         rows = Seq(
             SummaryListRow(
                 key = Key(content = Text(messages("changeAccount.table.name"))),
-                value = Value(content = Text(accountDetails.accountHolderName.fold(claimantName)(_.value))
-                ),
+                value = Value(content = Text(accountDetails.accountHolderName.fold(claimantName)(_.value))),
                 actions = None
             ),
             SummaryListRow(
                 key = Key(content = Text(messages("changeAccount.table.sort.code"))),
-                value = Value(content = Text(formatSensitiveSort(accountDetails.sortCode.fold("Sort not found")(_.value)))
-                ),
+                value = Value(content = Text(formatSensitiveSort(accountDetails.sortCode.fold("Sort not found")(_.value)))),
                 actions = None
             ),
             SummaryListRow(
                 key = Key(content = Text(messages("changeAccount.table.account.number"))),
-                value = Value(content = Text(formatSensitiveAccNumber(accountDetails.bankAccountNumber.fold("Account not found")(_.number)))
-            ),
+                value = Value(content = Text(formatSensitiveAccNumber(accountDetails.bankAccountNumber.fold("Account not found")(_.number)))),
                 actions = None
             )
         )
     ).withAttribute("id" -> "account-details-table")
-)
-}
+)}
 
 @altDetailsTableAsSummaryList ={@govukSummaryList(
         SummaryList(
             rows = Seq(
             SummaryListRow(
                 key = Key(content = Text(messages("changeAccount.table.name"))),
-                value = Value(content = Text(accountDetails.accountHolderName.fold(claimantName)(_.value))
-            ),
+                value = Value(content = Text(accountDetails.accountHolderName.fold(claimantName)(_.value))),
                 actions = None
             )
         )
@@ -77,9 +73,7 @@
 
 @note(content = messages("changeAccount.notification.text"),
     id = Some("info-notice")
-)
-
-}
+)}
 
 @layout(pageTitle = titleNoForm(messages("changeAccount.title"))) {
 
@@ -105,15 +99,8 @@
     @para(messages("changeAccount.paragraph.2", formLink))
 
     <div class="govuk-button-group">
-        <a class="govuk-button" href="@controllers.cob.routes.NewAccountDetailsController.onPageLoad(NormalMode)"
-           data-module="govuk-button" id="continue-button">
-            @messages("changeAccount.button.1")
-        </a>
-        <a class="govuk-button govuk-button--secondary"
-           href="@controllers.cob.routes.AccountNotChangedController.onPageLoad()"
-           data-module="govuk-button" id="do-not-change-button">
-            @messages("changeAccount.button.2")
-        </a>
+        @buttonLink("continue-button", "changeAccount.button.1", controllers.cob.routes.NewAccountDetailsController.onPageLoad(NormalMode))
+        @buttonLink("do-not-change-button", "changeAccount.button.2", controllers.cob.routes.AccountNotChangedController.onPageLoad(), Some("govuk-button--secondary"))
     </div>
 
 }

--- a/app/views/components/ButtonLink.scala.html
+++ b/app/views/components/ButtonLink.scala.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(id: String, message: String, call: Call, classes: Option[String] = None)(implicit messages: Messages)
+
+<a id="@id" @classes.fold{class="govuk-button"}{classes => class="govuk-button @classes"} data-module="govuk-button" role="button" href="@call">@messages(message)</a>

--- a/app/views/ftnae/CheckYourAnswersView.scala.html
+++ b/app/views/ftnae/CheckYourAnswersView.scala.html
@@ -23,7 +23,8 @@
     h2: HeadingH2,
     warningText: Warning,
     para: ParagraphBody,
-    link: Link
+    link: Link,
+    buttonLink: ButtonLink
 )
 
 @(list: SummaryList)(implicit request: Request[_], messages: Messages)
@@ -39,8 +40,6 @@
     @warningText(Html(messages("checkYourAnswers.warning")))
 
     <div class="govuk-button-group">
-        <a class="govuk-button" href="@controllers.ftnae.routes.PaymentsExtendedController.onPageLoad()" data-module="govuk-button">
-            @messages("checkYourAnswers.submit")
-        </a>
+        @buttonLink("continue-button", "checkYourAnswers.submit", controllers.ftnae.routes.PaymentsExtendedController.onPageLoad())
     </div>
 }


### PR DESCRIPTION
[[SB-1599]](https://jira.tools.tax.service.gov.uk/browse/SB-1599)

New component to centralise concerns of links as button and add the button role.

This is important for the likes of screen readers as certain controls interacts differently with anchor links and true buttons. Adding `role="button"` explicitly tells these tools to treat it as a button.
A similar link is on use in the FTNAE Check Your Answers view so this has been updated as well so it not later flagged when FT4 is audited.