### PR TITLE
SB-1718 Change HTTP status code of Service Unavailable page to 503

### DIFF
--- a/app/controllers/ServiceUnavailableController.scala
+++ b/app/controllers/ServiceUnavailableController.scala
@@ -30,6 +30,6 @@ class ServiceUnavailableController @Inject() (
     with I18nSupport {
   def onPageLoad: Action[AnyContent] =
     Action { implicit request =>
-      Ok(view())
+      ServiceUnavailable(view())
     }
 }

--- a/test/controllers/ServiceUnavailableControllerSpec.scala
+++ b/test/controllers/ServiceUnavailableControllerSpec.scala
@@ -37,7 +37,7 @@ class ServiceUnavailableControllerSpec extends BaseISpec with EitherValues {
 
         val view = application.injector.instanceOf[ServiceUnavailableTemplate]
 
-        status(result) mustEqual OK
+        status(result) mustEqual SERVICE_UNAVAILABLE
         assertSameHtmlAfter(removeNonce)(
           contentAsString(result),
           view()(request, messages(application, request)).toString


### PR DESCRIPTION
Example of HTTP GET for `/child-benefit/service-down`:
<img width="625" alt="Screenshot 2023-06-12 at 16 12 00" src="https://github.com/hmrc/child-benefit-view-frontend/assets/10521622/403ba37e-72d9-4b5a-beeb-e843baaada13">
