### PR TITLE
[SB-1622]: Behaviour driven '(opens in new tab)'

### DIFF
--- a/app/views/components/Link.scala.html
+++ b/app/views/components/Link.scala.html
@@ -16,6 +16,6 @@
 
 @this()
 
-@(id: String, text: String, call: Call, newTab: Boolean = true, classes: String = "govuk-link govuk-link--no-visited-state")
+@(id: String, text: String, call: Call, newTab: Boolean = true, classes: String = "govuk-link govuk-link--no-visited-state")(implicit messages: Messages)
 
-<a class="@classes" href="@call" @if(newTab) { target="_blank" rel="noopener noreferrer" } id="@id">@text</a>
+<a class="@classes" href="@call" @if(newTab) { target="_blank" rel="noopener noreferrer" } id="@id">@text @if(newTab){@messages("site.opensInNewTab")}</a>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -10,6 +10,7 @@ site.continue = Yn eich blaen
 site.signIn = Mewngofnodi
 site.govuk = GOV.UK
 site.technicalProblemMessage = A yw’r dudalen hon yn gweithio’n iawn? (yn agor mewn tab newydd)
+site.opensInNewTab = (yn agor tab newydd)
 
 # ---------- Date Section -----------------------
 
@@ -50,8 +51,8 @@ proofOfEntitlement.firstChild = {0} ar gyfer y plentyn hynaf neu’r unig blenty
 proofOfEntitlement.additionalchild = {0} ar gyfer pob plentyn ychwanegol
 proofOfEntitlement.entitlementdetail.title = Manylion hawl yr hawliwr
 proofOfEntitlement.entitlementdetail.p1 = Os yw’ch cyfeiriad neu unrhyw enwau’n anghywir, gallwch {0} neu am newidiadau i {1}, a byddwn yn eu diweddaru ar eich cyfer.
-proofOfEntitlement.entitlementdetail.p1.link.1 = rhoi gwybod i ni am newidiadau i’ch amgylchiadau (yn agor tab newydd)
-proofOfEntitlement.entitlementdetail.p1.link.2 = amgylchiadau’ch plentyn neu’ch plant (yn agor tab newydd)
+proofOfEntitlement.entitlementdetail.p1.link.1 = rhoi gwybod i ni am newidiadau i’ch amgylchiadau
+proofOfEntitlement.entitlementdetail.p1.link.2 = amgylchiadau’ch plentyn neu’ch plant
 proofOfEntitlement.claimantname = Enw
 proofOfEntitlement.address = Cyfeiriad
 proofOfEntitlement.amount = Swm
@@ -94,7 +95,7 @@ paymentHistory.v6.p2 = Mae ein cofnodion yn dangos nad ydych wedi cael unrhyw da
 paymentHistory.v1.header = Cael gwybod pryd y cewch eich talu nesaf
 paymentHistory.v1.p1 = Os ydych yn cael eich talu pob 4 wythnos, gallwch weithio allan pryd y cewch eich talu nesaf drwy rifo 4 wythnos ymlaen o’ch taliad diwethaf.
 paymentHistory.v1.p2 = Cewch eich talu cyn hynny os {0}
-paymentHistory.v1.link.text = mae’r taliad yn ddyledus ar ŵyl banc (yn agor tab newydd)
+paymentHistory.v1.link.text = mae’r taliad yn ddyledus ar ŵyl banc
 paymentHistory.v1.p3 = Mae Budd-dal Plant yn cael ei dalu’n wythnosol, neu bob 4 wythnos. Nid yw’n cael ei dalu yn ôl misoedd calendr.
 
 # ---- Variant 3 - HICBC with payments in last 2 years
@@ -332,7 +333,7 @@ notEntitled.title = Nid oes gennych hawl i barhau i gael Budd-dal Plant
 notEntitled.heading = Nid oes gennych hawl i barhau i gael Budd-dal Plant
 notEntitled.p1 = Dim ond os yw’r canlynol yn wir am y person ifanc y bydd gennych hawl i daliadau parhaus:
 notEntitled.bulletPoint1 = bydd yn parhau mewn {0}
-notEntitled.bulletPoint1.linkText = addysg amser llawn nad yw’n addysg uwch neu hyfforddiant cymeradwy (yn agor tab newydd)
+notEntitled.bulletPoint1.linkText = addysg amser llawn nad yw’n addysg uwch neu hyfforddiant cymeradwy
 notEntitled.bulletPoint2 = bydd yn astudio am fwy na 12 awr yr wythnos ar gyfartaledd yn ystod y tymor
 notEntitled.p2 = Defnyddiwch ffurflen Budd-dal Plant wahanol i {0}.
 notEntitled.p2.linkText = roi gwybod i ni fod y person ifanc yn parhau â hyfforddiant cymeradwy
@@ -382,7 +383,7 @@ paymentsExtended.heading = Mae’ch taliadau Budd-dal Plant wedi cael eu hymesty
 paymentsExtended.whatHappensNext.h2 = Yr hyn sy’n digwydd nesaf
 paymentsExtended.p1 = Bydd y taliadau Budd-dal Plant ar gyfer {0} yn cael eu talu tra bo’r plentyn hwnnw’n parhau ag addysg amser llawn nad yw’n addysg uwch. Byddwch yn cael y taliadau hyn am {1}.
 paymentsExtended.changeOfCircumstances = Mae’n rhaid i chi {0}.
-paymentsExtended.changeOfCircumstances.linkText = roi gwybod i’r swyddfa Budd-dal Plant ar unwaith os bydd ei amgylchiadau yn newid (yn agor tab newydd)
+paymentsExtended.changeOfCircumstances.linkText = roi gwybod i’r swyddfa Budd-dal Plant ar unwaith os bydd ei amgylchiadau yn newid
 paymentsExtended.startPage.p1 = Rhowch wybod i ni am berson ifanc arall sy’n parhau â’i addysg
 paymentsExtended.ifYouReceive.h3 = Os ydych yn cael Credyd Treth Plant
 paymentsExtended.p2 = Mae hefyd angen i chi {0}.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -16,6 +16,7 @@ site.startAgain = Start again
 site.signIn = Sign in
 site.govuk = GOV.UK
 site.technicalProblemMessage = Is this page not working properly? (opens in new tab)
+site.opensInNewTab = (opens in new tab)
 
 # ---------- Date Section -----------------------
 date.day = Day
@@ -78,8 +79,8 @@ proofOfEntitlement.firstChild = {0} for the eldest or only child
 proofOfEntitlement.additionalchild = {0} for each additional child
 proofOfEntitlement.entitlementdetail.title = Claimant’s entitlement details
 proofOfEntitlement.entitlementdetail.p1 = If your address or any names are incorrect, you can {0} or about {1} and we’ll update them for you.
-proofOfEntitlement.entitlementdetail.p1.link.1 = tell us about changes to your circumstances (opens in new tab)
-proofOfEntitlement.entitlementdetail.p1.link.2 = your child’s or children’s circumstances (opens in new tab)
+proofOfEntitlement.entitlementdetail.p1.link.1 = tell us about changes to your circumstances
+proofOfEntitlement.entitlementdetail.p1.link.2 = your child’s or children’s circumstances
 proofOfEntitlement.claimantname = Name
 proofOfEntitlement.address = Address
 proofOfEntitlement.amount = Amount
@@ -122,7 +123,7 @@ paymentHistory.v6.p2 = Our records show that you have not received any payments 
 paymentHistory.v1.header = Find out when you’ll be paid next
 paymentHistory.v1.p1 = If you’re paid every 4 weeks, you can find out when you’ll be paid next by counting 4 weeks forward from your last payment.
 paymentHistory.v1.p2 = You’ll be paid earlier if {0}
-paymentHistory.v1.link.text = the payment’s due on a bank holiday (opens in new tab)
+paymentHistory.v1.link.text = the payment’s due on a bank holiday
 paymentHistory.v1.p3 = Child Benefit is paid weekly or every 4 weeks. It is not paid by calendar month.
 
 # ---- Variant 3 - HICBC with payments in last 2 years
@@ -364,7 +365,7 @@ notEntitled.title = You’re not entitled to continuing Child Benefit
 notEntitled.heading = You’re not entitled to continuing Child Benefit
 notEntitled.p1 = You’re only entitled to continued payments if the young person will be:
 notEntitled.bulletPoint1 = staying in {0}
-notEntitled.bulletPoint1.linkText = full-time non-advanced education or approved training (opens in new tab)
+notEntitled.bulletPoint1.linkText = full-time non-advanced education or approved training
 notEntitled.bulletPoint2 = studying for more than an average of 12 hours a week in term time
 notEntitled.p2 = Use a different Child Benefit form to {0}.
 notEntitled.p2.linkText = tell us that the young person is staying in approved training
@@ -414,7 +415,7 @@ paymentsExtended.heading = Your Child Benefit payments have been extended
 paymentsExtended.whatHappensNext.h2 = What happens next
 paymentsExtended.p1 = The Child Benefit payments for {0} will now be paid while they stay in full-time non-advanced education. You’ll receive the payments for {1}.
 paymentsExtended.changeOfCircumstances = You must {0}.
-paymentsExtended.changeOfCircumstances.linkText = tell the Child Benefit office immediately if the young person’s circumstances change (opens in new tab)
+paymentsExtended.changeOfCircumstances.linkText = tell the Child Benefit office immediately if the young person’s circumstances change
 paymentsExtended.startPage.p1 = Tell us about another young person staying in education
 paymentsExtended.ifYouReceive.h3 = If you receive Child Tax Credit
 paymentsExtended.p2 = You also need to {0}.

--- a/test/views/cob/HICBCOptedOutPaymentsViewSpec.scala
+++ b/test/views/cob/HICBCOptedOutPaymentsViewSpec.scala
@@ -44,10 +44,11 @@ class HICBCOptedOutPaymentsViewSpec extends ViewSpecBase {
       view.text() must include(messages("hICBCOptedOutPayments.paragraph.1"))
     }
     "have some text with a link" in {
+      val expectedLinkText = s"${messages("hICBCOptedOutPayments.guide.link.text")} ${messages("site.opensInNewTab")}"
       view.text() must include(
-        messages("hICBCOptedOutPayments.paragraph.2", messages("hICBCOptedOutPayments.guide.link.text"))
+        messages("hICBCOptedOutPayments.paragraph.2", expectedLinkText)
       )
-      view.getElementById("guide-link").text mustBe messages("hICBCOptedOutPayments.guide.link.text")
+      view.getElementById("guide-link").text mustBe expectedLinkText
     }
 
   }


### PR DESCRIPTION
[SB-1622] which will implement the fix for [SB-1609]

Make '(opens in new tab)' text global and tied to link's behaviour. This reduces the need to adding 'open's in a new tab'/'yn agor tab newydd' to link text through the messages file and ensure that a link that is set to open in a new tab states so we cannot get divergence.