### PR TITLE
Whitespace misplaced for new tab links: moved

### DIFF
--- a/app/views/components/Link.scala.html
+++ b/app/views/components/Link.scala.html
@@ -18,4 +18,4 @@
 
 @(id: String, text: String, call: Call, newTab: Boolean = true, classes: String = "govuk-link govuk-link--no-visited-state")(implicit messages: Messages)
 
-<a class="@classes" href="@call" @if(newTab) { target="_blank" rel="noopener noreferrer" } id="@id">@text @if(newTab){@messages("site.opensInNewTab")}</a>
+<a class="@classes" href="@call" @if(newTab) { target="_blank" rel="noopener noreferrer" } id="@id">@text@if(newTab){ @messages("site.opensInNewTab")}</a>


### PR DESCRIPTION
[[SB-1622]](https://jira.tools.tax.service.gov.uk/browse/SB-1622)

White space before the conditional so space appearing on none new tab links:
<img width="369" alt="image" src="https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/ca51c22f-e3d8-4edf-ad20-fcb81ccf78cb">

Corrected to so it beyond the conditional:
<img width="476" alt="image" src="https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/2304392e-ce53-4fbd-9022-a7befd33e6b0">