### PR TITLE
[SB-1551]: Remove inapplicable back links

### DIFF
--- a/app/views/NoAccountFoundView.scala.html
+++ b/app/views/NoAccountFoundView.scala.html
@@ -29,7 +29,7 @@
 
 @layout(
     pageTitle    = titleNoForm(messages("noAccountFound.header")),
-    showBackLink = true,
+    showBackLink = false,
     dataLayer = Some(DataLayer(event = "journey_step", navigate = "no match"))
 ) {
 

--- a/app/views/ProofOfEntitlement.scala.html
+++ b/app/views/ProofOfEntitlement.scala.html
@@ -44,8 +44,9 @@
                         )}
 
 @layout(pageTitle = titleNoForm(messages("proofOfEntitlement.title")),
-            dataLayer = Some(DataLayer(event = "journey_step", navigate = "proof of entitlement")),
-            showBackLink = true) {
+        dataLayer = Some(DataLayer(event = "journey_step", navigate = "proof of entitlement")),
+        showBackLink = false
+) {
 
     @heading(messages("proofOfEntitlement.title"), caption = Some(entitlement.claimant.name.value))
 

--- a/app/views/paymenthistory/NoPaymentHistory.scala.html
+++ b/app/views/paymenthistory/NoPaymentHistory.scala.html
@@ -43,7 +43,8 @@
 
 @layout(pageTitle = messages("paymentHistory.pageTitle"),
     dataLayer = Some(DataLayer(event = "journey_step", navigate = navigatePaymentHistory(pageVariant))),
-    showBackLink = true) {
+    showBackLink = false
+) {
 
     @heading(messages("paymentHistory.title"), caption = Some(entitlement.claimant.name.value))
 

--- a/app/views/paymenthistory/PaymentHistory.scala.html
+++ b/app/views/paymenthistory/PaymentHistory.scala.html
@@ -48,7 +48,8 @@
 
 @layout(pageTitle = messages("paymentHistory.pageTitle"),
     dataLayer = Some(DataLayer(event = "journey_step", navigate = navigatePaymentHistory(pageVariant))),
-    showBackLink = true) {
+    showBackLink = false
+) {
 
     @heading(messages("paymentHistory.title"), caption = Some(entitlement.claimant.name.value))
 


### PR DESCRIPTION
[[SB-1551]](https://jira.tools.tax.service.gov.uk/browse/SB-1551)

Remove back link from pages where there is no determinate previous step to go back to at the request of the design team.

Update Screen shots:-
No Account Found
![SB-1551 - No Account - Updated](https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/fbff48df-f686-4ed6-baa8-a47cc1b8b227)
Payment History (w/ payment history)
![SB-1551 - PH (history) - Updated](https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/51a97a82-25e3-41c4-901b-c8b56fe423df)
Payment History (w/o payment history)
![SB-1551 - PH (no history) - Updated](https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/bada7b5d-1279-4dd0-817e-1b02f5e61607)
View Proof of Entitlement
![SB-1551 - PoE - Updated](https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/0022c0db-52af-4b53-bf9c-e64c7afc761a)