### PR TITLE
[SB-1849] Add the Credit Union account type to Change of Bank

### DIFF
--- a/app/forms/cob/WhatTypeOfAccountFormProvider.scala
+++ b/app/forms/cob/WhatTypeOfAccountFormProvider.scala
@@ -44,6 +44,7 @@ class WhatTypeOfAccountFormProvider @Inject() extends Mappings {
       {
         case (AccountType.Sole, _)          => true
         case (AccountType.Joint, jointType) => jointType.isDefined
+        case (AccountType.CreditUnion, _)   => true
       }
     )
 
@@ -57,7 +58,7 @@ class WhatTypeOfAccountFormProvider @Inject() extends Mappings {
         WhatTypeOfAccount.JointHeldByClaimant
       case (AccountType.Joint, Some(JointAccountType.NotHeldByClaimant)) =>
         WhatTypeOfAccount.JointNotHeldByClaimant
-      case (_, None) => WhatTypeOfAccount.Sole
+      case (AccountType.CreditUnion, _) => WhatTypeOfAccount.CreditUnion
     }
 
   private def unbind(whatAccountType: WhatTypeOfAccount): (AccountType, Option[JointAccountType]) =
@@ -67,6 +68,7 @@ class WhatTypeOfAccountFormProvider @Inject() extends Mappings {
         (AccountType.Joint, Some(JointAccountType.HeldByClaimant))
       case WhatTypeOfAccount.JointNotHeldByClaimant =>
         (AccountType.Joint, Some(JointAccountType.NotHeldByClaimant))
+      case WhatTypeOfAccount.CreditUnion => (AccountType.CreditUnion, None)
     }
 
 }

--- a/app/models/WithMessage.scala
+++ b/app/models/WithMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/cob/WhatTypeOfAccount.scala
+++ b/app/models/cob/WhatTypeOfAccount.scala
@@ -39,7 +39,11 @@ object WhatTypeOfAccount extends Enumerable.Implicits {
       )
       with WhatTypeOfAccount
 
-  val values: List[WhatTypeOfAccount] = List(Sole, JointHeldByClaimant, JointNotHeldByClaimant)
+  case object CreditUnion
+      extends WithMessage("credit_union", m => m("whatTypeOfAccount.options.creditUnion"))
+      with WhatTypeOfAccount
+
+  val values: List[WhatTypeOfAccount] = List(Sole, JointHeldByClaimant, JointNotHeldByClaimant, CreditUnion)
 
   implicit val enumerable: Enumerable[WhatTypeOfAccount] =
     Enumerable(values.map(v => v.toString -> v): _*)
@@ -54,8 +58,11 @@ object AccountType extends Enumerable.Implicits {
 
   case object Sole  extends WithMessage("sole", m => m("whatTypeOfAccount.options.sole")) with AccountType
   case object Joint extends WithMessage("joint", m => m("whatTypeOfAccount.options.joint")) with AccountType
+  case object CreditUnion
+      extends WithMessage("credit-union", m => m("whatTypeOfAccount.options.creditUnion"))
+      with AccountType
 
-  val values: List[AccountType] = List(Sole, Joint)
+  val values: List[AccountType] = List(Sole, Joint, CreditUnion)
 
   implicit val enumerable: Enumerable[AccountType] =
     Enumerable(values.map(v => v.toString -> v): _*)

--- a/app/views/cob/NewAccountDetailsView.scala.html
+++ b/app/views/cob/NewAccountDetailsView.scala.html
@@ -55,6 +55,10 @@
       @warningText(Html(messages("newAccountDetails.warningNotHeldByClaimant")))
     }
 
+    @if(accountType == WhatTypeOfAccount.CreditUnion) {
+      @warningText(Html(messages("newAccountDetails.warningCreditUnion")))
+    }
+
     @formHelper(action = controllers.cob.routes.NewAccountDetailsController.onSubmit(mode), Symbol("autoComplete") -> "off") {
         @if(form.errors.map(_.key).contains("bacsErrorTop")) {
             @paragraph(messages(form.errors.find(_.key.equals("bacsErrorTop")).map(_.message).get), "govuk-error-message", Some("bacsErrorTop"))
@@ -75,6 +79,8 @@
                     messages("newAccountDetails.jointHeldnewAccountHoldersNameHint")
                   case WhatTypeOfAccount.JointNotHeldByClaimant =>
                     messages("newAccountDetails.jointNotHeldnewAccountHoldersNameHint")
+                  case WhatTypeOfAccount.CreditUnion =>
+                    messages("newAccountDetails.creditUnionAccountHoldersNameHint")
                 }
               )
             )

--- a/app/views/cob/WhatTypeOfAccountView.scala.html
+++ b/app/views/cob/WhatTypeOfAccountView.scala.html
@@ -72,12 +72,16 @@
         items = Seq(
           RadioItem(
             content = Text(AccountType.Sole.message),
-            value = Some(AccountType.Sole.toString),
+            value = Some(AccountType.Sole.toString)
           ),
           RadioItem(
             content = Text(messages("whatTypeOfAccount.options.joint")),
             value = Some(AccountType.Joint.toString),
             conditionalHtml = Some(inner)
+          ),
+          RadioItem(
+            content = Text(AccountType.CreditUnion.message),
+            value = Some(AccountType.CreditUnion.toString)
           )
         )
       )

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -162,9 +162,10 @@ whatTypeOfAccount.title = Pa fath o gyfrif yw hwn?
 whatTypeOfAccount.heading = Pa fath o gyfrif yw hwn?
 whatTypeOfAccount.options.sole = Cyfrif unigol
 whatTypeOfAccount.options.joint = Cyfrif ar y cyd
+whatTypeOfAccount.options.creditUnion = Credit union account # TODO: SB-2032
 whatTypeOfAccount.options.jointHeldByClaimant = rydych yn rhannu’r cyfrif â rhywun
 whatTypeOfAccount.options.jointNotHeldByClaimant = nid chi yw deiliad y cyfrif
-whatTypeOfAccount.error.accountTypeRequired = Dewiswch ‘Cyfrif unigol’ neu ‘Cyfrif ar y cyd’
+whatTypeOfAccount.error.accountTypeRequired = Dewiswch ‘Cyfrif unigol’ neu ‘Cyfrif ar y cyd’ # TODO: SB-2032
 whatTypeOfAccount.error.jointTypeRequired = Dewiswch ‘Rydych yn rhannu’r cyfrif â rhywun’ neu ‘Nid chi yw deiliad y cyfrif’
 
 # ---------- Account Not Changed Section --------
@@ -178,10 +179,12 @@ newAccountDetails.heading = Beth yw manylion y cyfrif newydd?
 newAccountDetails.paragraph = Os byddwch yn newid i gyfrif sydd yn enw rhywun arall, chi sy’n gyfrifol am sicrhau eich bod yn cael yr arian a bod yr arian yn cael ei ddefnyddio yn unol â’ch dymuniadau.
 newAccountDetails.warningHeldByClaimant = Nodwch enw deiliad arall y cyfrif yn y blwch ‘Enw sydd ar y cyfrif’.
 newAccountDetails.warningNotHeldByClaimant = Nodwch enw un o ddeiliaid y cyfrif yn unig.
+newAccountDetails.warningCreditUnion = Enter your name, not the name of the credit union. # TODO: SB-2032
 newAccountDetails.newAccountHoldersName = Yr enw sydd ar y cyfrif
 newAccountDetails.newAccountHoldersNameHint = Nodwch yr enw cyntaf a’r cyfenw yn unig. Peidiwch â defnyddio llythrennau cyntaf na theitlau, megis Mr neu Mrs
 newAccountDetails.jointHeldnewAccountHoldersNameHint = Nodwch enw cyntaf a chyfenw deiliad arall y cyfrif. Peidiwch â defnyddio llythrennau cyntaf na theitlau, megis Mr neu Mrs
 newAccountDetails.jointNotHeldnewAccountHoldersNameHint = Nodwch enw cyntaf a chyfenw un o ddeiliaid y cyfrif yn unig. Peidiwch â defnyddio llythrennau cyntaf na theitlau megis Mr neu Mrs
+newAccountDetails.creditUnionAccountHoldersNameHint = Nodwch yr enw cyntaf a’r cyfenw yn unig. Peidiwch â defnyddio llythrennau cyntaf na theitlau, megis Mr neu Mrs
 newAccountDetails.newSortCode = Cod didoli
 newAccountDetails.newSortCodeHint = Mae’n rhaid i hyn fod yn 6 digid o hyd
 newAccountDetails.newAccountNumber = Rhif y cyfrif

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -162,10 +162,10 @@ whatTypeOfAccount.title = Pa fath o gyfrif yw hwn?
 whatTypeOfAccount.heading = Pa fath o gyfrif yw hwn?
 whatTypeOfAccount.options.sole = Cyfrif unigol
 whatTypeOfAccount.options.joint = Cyfrif ar y cyd
-whatTypeOfAccount.options.creditUnion = Credit union account # TODO: SB-2032
+whatTypeOfAccount.options.creditUnion = Credit union account # TODO: see SB-2032
 whatTypeOfAccount.options.jointHeldByClaimant = rydych yn rhannu’r cyfrif â rhywun
 whatTypeOfAccount.options.jointNotHeldByClaimant = nid chi yw deiliad y cyfrif
-whatTypeOfAccount.error.accountTypeRequired = Dewiswch ‘Cyfrif unigol’ neu ‘Cyfrif ar y cyd’ # TODO: SB-2032
+whatTypeOfAccount.error.accountTypeRequired = Dewiswch ‘Cyfrif unigol’ neu ‘Cyfrif ar y cyd’ # TODO: see SB-2032
 whatTypeOfAccount.error.jointTypeRequired = Dewiswch ‘Rydych yn rhannu’r cyfrif â rhywun’ neu ‘Nid chi yw deiliad y cyfrif’
 
 # ---------- Account Not Changed Section --------
@@ -179,7 +179,7 @@ newAccountDetails.heading = Beth yw manylion y cyfrif newydd?
 newAccountDetails.paragraph = Os byddwch yn newid i gyfrif sydd yn enw rhywun arall, chi sy’n gyfrifol am sicrhau eich bod yn cael yr arian a bod yr arian yn cael ei ddefnyddio yn unol â’ch dymuniadau.
 newAccountDetails.warningHeldByClaimant = Nodwch enw deiliad arall y cyfrif yn y blwch ‘Enw sydd ar y cyfrif’.
 newAccountDetails.warningNotHeldByClaimant = Nodwch enw un o ddeiliaid y cyfrif yn unig.
-newAccountDetails.warningCreditUnion = Enter your name, not the name of the credit union. # TODO: SB-2032
+newAccountDetails.warningCreditUnion = Enter your name, not the name of the credit union. # TODO: see SB-2032
 newAccountDetails.newAccountHoldersName = Yr enw sydd ar y cyfrif
 newAccountDetails.newAccountHoldersNameHint = Nodwch yr enw cyntaf a’r cyfenw yn unig. Peidiwch â defnyddio llythrennau cyntaf na theitlau, megis Mr neu Mrs
 newAccountDetails.jointHeldnewAccountHoldersNameHint = Nodwch enw cyntaf a chyfenw deiliad arall y cyfrif. Peidiwch â defnyddio llythrennau cyntaf na theitlau, megis Mr neu Mrs

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -193,9 +193,10 @@ whatTypeOfAccount.title = What type of account is it?
 whatTypeOfAccount.heading = What type of account is it?
 whatTypeOfAccount.options.sole = Sole account
 whatTypeOfAccount.options.joint = Joint account
+whatTypeOfAccount.options.creditUnion = Credit union account
 whatTypeOfAccount.options.jointHeldByClaimant = you share with someone
 whatTypeOfAccount.options.jointNotHeldByClaimant = not held by you
-whatTypeOfAccount.error.accountTypeRequired = Select ‘Sole account’ or ‘Joint account’ 
+whatTypeOfAccount.error.accountTypeRequired = Select ‘Sole account’, ‘Joint account’ or ‘Credit union account’
 whatTypeOfAccount.error.jointTypeRequired = Select ‘you share with someone’ or ‘not held by you’ 
 
 # ---------- Account Not Changed Section --------
@@ -209,10 +210,12 @@ newAccountDetails.heading = What are the new account details?
 newAccountDetails.paragraph = If you change to an account in someone else’s name, you’re responsible for making sure you get the money and that it’s used how you want.
 newAccountDetails.warningHeldByClaimant = Enter the name of the other account holder in ‘Name on the account’.
 newAccountDetails.warningNotHeldByClaimant = Only enter the name of one of the account holders.
+newAccountDetails.warningCreditUnion = Enter your name, not the name of the credit union.
 newAccountDetails.newAccountHoldersName = Name on the account
 newAccountDetails.newAccountHoldersNameHint = Only enter the first and last name, and do not use initials or titles like Mr or Mrs
 newAccountDetails.jointHeldnewAccountHoldersNameHint = Enter the first and last name of the other account holder, and do not use initials or titles like Mr or Mrs
 newAccountDetails.jointNotHeldnewAccountHoldersNameHint = Enter the first and last name of just one of the account holders, and do not use initials or titles like Mr or Mrs
+newAccountDetails.creditUnionAccountHoldersNameHint = Only enter your first and last name, and do not use initials or titles like Mr or Mrs
 newAccountDetails.newSortCode = Sort code
 newAccountDetails.newSortCodeHint = Must be 6 digits long
 newAccountDetails.newAccountNumber = Account number


### PR DESCRIPTION
[[SB-1849]](https://jira.tools.tax.service.gov.uk/browse/SB-1849)

Add a new account type to Change of Bank, Credit Union, with it's own set of messaging.