### PR TITLE
[SB-1606]: Update display of existing bank details

### DIFF
--- a/app/controllers/actions/VerifyHICBCAction.scala
+++ b/app/controllers/actions/VerifyHICBCAction.scala
@@ -19,11 +19,9 @@ package controllers.actions
 import models.CBEnvelope
 import models.changeofbank.ClaimantBankInformation
 import models.requests.IdentifierRequest
-
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionFilter, Result}
-import services.AuditService
-import services.ChangeOfBankService
+import services.{AuditService, ChangeOfBankService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import utils.handlers.ErrorHandler

--- a/app/services/ChangeOfBankService.scala
+++ b/app/services/ChangeOfBankService.scala
@@ -31,7 +31,7 @@ import play.api.mvc.{AnyContent, Request, Result}
 import repositories.SessionRepository
 import services.ChangeOfBankService._
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.helpers.ClaimantBankInformationHelper.formatClaimantBankInformation
+import utils.helpers.ClaimantBankInformationHelper.{formatBankAccountInformation, formatClaimantBankInformation}
 import views.html.cob.ChangeAccountView
 
 import java.time.LocalDate
@@ -76,13 +76,14 @@ class ChangeOfBankService @Inject() (
   ): CBEnvelope[Result] = {
     for {
       claimantInfo     <- retrieveBankClaimantInfo
-      childBenefitPage <- validateToChangeOfBankPage(claimantInfo, view)
+      viewClaimantInfo <- CBEnvelope(formatBankAccountInformation(claimantInfo))
+      childBenefitPage <- validateToChangeOfBankPage(viewClaimantInfo, view)
     } yield {
       auditService.auditChangeOfBankAccountDetails(
         request.nino.nino,
         "Successful",
         request,
-        claimantInfo
+        viewClaimantInfo
       )
       childBenefitPage
     }

--- a/app/utils/helpers/ClaimantBankInformationHelper.scala
+++ b/app/utils/helpers/ClaimantBankInformationHelper.scala
@@ -16,14 +16,35 @@
 
 package utils.helpers
 
-import models.changeofbank.ClaimantBankInformation
+import models.changeofbank.{BankAccountNumber, ClaimantBankInformation, SortCode}
 import models.common.{FirstForename, Surname}
+import play.api.i18n.Messages
 import utils.helpers.StringHelper.toTitleCase
 
 object ClaimantBankInformationHelper {
+  val accountNumberTake = 4
+
   def formatClaimantBankInformation(information: ClaimantBankInformation): ClaimantBankInformation =
     information.copy(
       firstForename = FirstForename(toTitleCase(information.firstForename.value)),
       surname = Surname(toTitleCase(information.surname.value))
+    )
+
+  def formatBankAccountInformation(
+      information:     ClaimantBankInformation
+  )(implicit messages: Messages): ClaimantBankInformation =
+    information.copy(
+      financialDetails = information.financialDetails.copy(
+        bankAccountInformation = information.financialDetails.bankAccountInformation.copy(
+          sortCode = information.financialDetails.bankAccountInformation.sortCode
+            .map(s => SortCode(s.value.grouped(2).reduce((prev, next) => s"$prev-$next"))),
+          bankAccountNumber = information.financialDetails.bankAccountInformation.bankAccountNumber
+            .map(n =>
+              BankAccountNumber(
+                s"${messages("changeAccount.table.ending.in")} ${n.number.takeRight(accountNumberTake)}"
+              )
+            )
+        )
+      )
     )
 }

--- a/app/views/ViewUtils.scala
+++ b/app/views/ViewUtils.scala
@@ -77,13 +77,4 @@ object ViewUtils {
       case EntitlementEndedButNoPaymentsInLastTwoYears        => "payment details - inactive - no payments"
     }
 
-  def formatSensitiveSort(raw: String): String = {
-    s"""**-**-${raw.filter(_.isDigit).substring(4)}"""
-  }
-
-  def formatSensitiveAccNumber(raw: String): String = {
-    val asterisks: String = (for (_ <- 1 to (raw.length - 4)) yield "*").mkString
-    s"""$asterisks${raw.takeRight(4)}"""
-  }
-
 }

--- a/app/views/cob/ChangeAccountView.scala.html
+++ b/app/views/cob/ChangeAccountView.scala.html
@@ -46,12 +46,12 @@
             ),
             SummaryListRow(
                 key = Key(content = Text(messages("changeAccount.table.sort.code"))),
-                value = Value(content = Text(formatSensitiveSort(accountDetails.sortCode.fold("Sort not found")(_.value)))),
+                value = Value(content = Text(accountDetails.sortCode.fold("Sort not found")(_.value))),
                 actions = None
             ),
             SummaryListRow(
                 key = Key(content = Text(messages("changeAccount.table.account.number"))),
-                value = Value(content = Text(formatSensitiveAccNumber(accountDetails.bankAccountNumber.fold("Account not found")(_.number)))),
+                value = Value(content = Text(accountDetails.bankAccountNumber.fold("Account not found")(_.number))),
                 actions = None
             )
         )

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -144,6 +144,7 @@ changeAccount.notification.text = Ni allwn ddangos y cod didoli na rhif y cyfrif
 changeAccount.table.name = Yr enw sydd ar y cyfrif:
 changeAccount.table.sort.code = Cod didoli:
 changeAccount.table.account.number = Rhif y cyfrif:
+changeAccount.table.ending.in = yn diweddu yn
 changeAccount.button.1 = Yn eich blaen
 changeAccount.button.2 = Peidio â newid
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -175,6 +175,7 @@ changeAccount.notification.text = We’re unable to show the sort code and accou
 changeAccount.table.name = Name on the account:
 changeAccount.table.sort.code = Sort code:
 changeAccount.table.account.number = Account number:
+changeAccount.table.ending.in = ending in
 changeAccount.button.1 = Continue
 changeAccount.button.2 = Do not change
 

--- a/test/controllers/cob/ChangeAccountControllerSpec.scala
+++ b/test/controllers/cob/ChangeAccountControllerSpec.scala
@@ -43,8 +43,8 @@ class ChangeAccountControllerSpec extends BaseISpec with ScalaCheckPropertyCheck
 
     val accountInfo = ClaimantBankAccountInformation(
       accountHolderName = Some(AccountHolderName("Mr J Doe")),
-      sortCode = Some(SortCode("112233")),
-      bankAccountNumber = Some(BankAccountNumber("12345678")),
+      sortCode = Some(SortCode("11-22-33")),
+      bankAccountNumber = Some(BankAccountNumber("ending in 5678")),
       buildingSocietyRollNumber = None
     )
 

--- a/test/services/AuditServiceSpec.scala
+++ b/test/services/AuditServiceSpec.scala
@@ -27,6 +27,7 @@ import org.mockito.Mockito.{times, verify}
 import org.mockito.MockitoSugar.mock
 import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatestplus.play.PlaySpec
+import play.api.i18n.Messages
 import play.api.libs.json.Writes
 import play.api.mvc.{Headers, Request}
 import play.api.test.FakeRequest
@@ -52,6 +53,7 @@ class AuditServiceSpec extends PlaySpec {
 
   protected implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   protected implicit val hc: HeaderCarrier    = HeaderCarrier()
+  protected implicit val messages: Messages = mock[Messages]
 
   val entitlementDetails: Option[ClaimantEntitlementDetails] =
     Some(
@@ -151,14 +153,14 @@ class AuditServiceSpec extends PlaySpec {
         AccountHolderName("Mr J Doe")
       )
       capturedBankDetails.accountNumber mustBe Some(
-        BankAccountNumber("12345678")
+        BankAccountNumber(s"${messages("changeAccount.table.ending.in")} 5678")
       )
-      capturedBankDetails.sortCode mustBe Some(SortCode("112233"))
+      capturedBankDetails.sortCode mustBe Some(SortCode("11-22-33"))
       capturedBankDetails.buildingSocietyRollNumber mustBe None
 
       capturedViewDetails.accountHolderName mustBe "Mr J Doe"
-      capturedViewDetails.accountNumber mustBe "****5678"
-      capturedViewDetails.sortCode mustBe "**-**-33"
+      capturedViewDetails.accountNumber mustBe s"${messages("changeAccount.table.ending.in")} 5678"
+      capturedViewDetails.sortCode mustBe "11-22-33"
     }
   }
   "auditPaymentDetails" should {

--- a/test/services/AuditServiceSpec.scala
+++ b/test/services/AuditServiceSpec.scala
@@ -51,9 +51,9 @@ class AuditServiceSpec extends PlaySpec {
   protected val optionalDataRequest: OptionalDataRequest[_] =
     OptionalDataRequest(request, "123", NationalInsuranceNumber(testNino), None)
 
-  protected implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
-  protected implicit val hc: HeaderCarrier    = HeaderCarrier()
-  protected implicit val messages: Messages = mock[Messages]
+  protected implicit val ec:       ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+  protected implicit val hc:       HeaderCarrier    = HeaderCarrier()
+  protected implicit val messages: Messages         = mock[Messages]
 
   val entitlementDetails: Option[ClaimantEntitlementDetails] =
     Some(

--- a/test/views/cob/ChangeAccountViewSpec.scala
+++ b/test/views/cob/ChangeAccountViewSpec.scala
@@ -28,7 +28,7 @@ class ChangeAccountViewSpec extends ViewSpecBase {
   val page: ChangeAccountView = inject[ChangeAccountView]
   val name: String            = "Cindy Boo"
   val details: ClaimantBankAccountInformation = ClaimantBankAccountInformation(
-    Some(AccountHolderName("Cindy")),
+    Some(AccountHolderName("w2saq1z ")),
     Some(SortCode("123456")),
     Some(BankAccountNumber("123456789")),
     Some(BuildingSocietyRollNumber("666666"))
@@ -54,7 +54,7 @@ class ChangeAccountViewSpec extends ViewSpecBase {
     }
 
     "have a caption/section header" in {
-      view.getElementById("section-header").text() mustBe "Cindy Boo"
+      view.getElementById("section-header").text() mustBe name
     }
 
     "have a warning" in {
@@ -72,8 +72,8 @@ class ChangeAccountViewSpec extends ViewSpecBase {
     }
     "have obscured details" when {
       "claimant has bank account" in {
-        view.getElementById("account-details-table").text must include("**-**-56")
-        view.getElementById("account-details-table").text must include("****6789")
+        view.getElementById("account-details-table").text must include(details.sortCode.get.value)
+        view.getElementById("account-details-table").text must include(details.bankAccountNumber.get.number)
       }
     }
 


### PR DESCRIPTION
Change display of existing Bank Details per accessibility recommendations.
The Sort Code is to be fully displayed and the Account Number is phrased as "ending in {last 4 digits}" to better be read using assistive technologies.
![SB-1606 - English](https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/38e2c2de-c198-4fab-af3c-f9bd268adb8e)
![SB-1606 - Cymraeg](https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/ef6ab88a-8908-4c9d-91e7-19075bbe74f0)
