### PR TITLE
[SB-1849]: Do not display account name warning credit union accounts

### DIFF
--- a/app/views/cob/NewAccountDetailsView.scala.html
+++ b/app/views/cob/NewAccountDetailsView.scala.html
@@ -47,7 +47,7 @@
       @warningText(Html(messages("newAccountDetails.warningHeldByClaimant")) )
     }
 
-    @if(form.errors.isEmpty && accountType != WhatTypeOfAccount.JointHeldByClaimant) {
+    @if(form.errors.isEmpty && accountType != WhatTypeOfAccount.JointHeldByClaimant && accountType != WhatTypeOfAccount.CreditUnion) {
       @paragraph(messages("newAccountDetails.paragraph"))
     }
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -163,10 +163,10 @@ whatTypeOfAccount.title = Pa fath o gyfrif yw hwn?
 whatTypeOfAccount.heading = Pa fath o gyfrif yw hwn?
 whatTypeOfAccount.options.sole = Cyfrif unigol
 whatTypeOfAccount.options.joint = Cyfrif ar y cyd
-whatTypeOfAccount.options.creditUnion = Credit union account # TODO: see SB-2032
+whatTypeOfAccount.options.creditUnion = Cyfrif undeb credyd
 whatTypeOfAccount.options.jointHeldByClaimant = rydych yn rhannu’r cyfrif â rhywun
 whatTypeOfAccount.options.jointNotHeldByClaimant = nid chi yw deiliad y cyfrif
-whatTypeOfAccount.error.accountTypeRequired = Dewiswch ‘Cyfrif unigol’ neu ‘Cyfrif ar y cyd’ # TODO: see SB-2032
+whatTypeOfAccount.error.accountTypeRequired = Dewiswch ‘Cyfrif unigolyn’, ‘Cyfrif ar y cyd’ neu ‘Cyfrif undeb credyd’
 whatTypeOfAccount.error.jointTypeRequired = Dewiswch ‘Rydych yn rhannu’r cyfrif â rhywun’ neu ‘Nid chi yw deiliad y cyfrif’
 
 # ---------- Account Not Changed Section --------
@@ -180,7 +180,7 @@ newAccountDetails.heading = Beth yw manylion y cyfrif newydd?
 newAccountDetails.paragraph = Os byddwch yn newid i gyfrif sydd yn enw rhywun arall, chi sy’n gyfrifol am sicrhau eich bod yn cael yr arian a bod yr arian yn cael ei ddefnyddio yn unol â’ch dymuniadau.
 newAccountDetails.warningHeldByClaimant = Nodwch enw deiliad arall y cyfrif yn y blwch ‘Enw sydd ar y cyfrif’.
 newAccountDetails.warningNotHeldByClaimant = Nodwch enw un o ddeiliaid y cyfrif yn unig.
-newAccountDetails.warningCreditUnion = Enter your name, not the name of the credit union. # TODO: see SB-2032
+newAccountDetails.warningCreditUnion = Nodwch eich enw, nid enw’r undeb credyd.
 newAccountDetails.newAccountHoldersName = Yr enw sydd ar y cyfrif
 newAccountDetails.newAccountHoldersNameHint = Nodwch yr enw cyntaf a’r cyfenw yn unig. Peidiwch â defnyddio llythrennau cyntaf na theitlau, megis Mr neu Mrs
 newAccountDetails.jointHeldnewAccountHoldersNameHint = Nodwch enw cyntaf a chyfenw deiliad arall y cyfrif. Peidiwch â defnyddio llythrennau cyntaf na theitlau, megis Mr neu Mrs


### PR DESCRIPTION
CoB: Do not display warning about account in another name for credit union accounts

Also incorporates [SB-2032](https://jira.tools.tax.service.gov.uk/browse/SB-2032) the temp values would cause issues for testing and releasing so since the Welsh has since been provided, getting it on to prevent issues.