### PR TITLE
SO-164: Confirm Child's Name in FTNAE Success

### DIFF
--- a/app/views/components/ConfirmationPanel.scala.html
+++ b/app/views/components/ConfirmationPanel.scala.html
@@ -20,6 +20,6 @@
 
 <div class="govuk-panel govuk-panel--confirmation">
     <h1 class="govuk-panel__title">
-        @message
+        @Html(message)
     </h1>
 </div>

--- a/app/views/ftnae/PaymentsExtendedView.scala.html
+++ b/app/views/ftnae/PaymentsExtendedView.scala.html
@@ -61,9 +61,9 @@
 }
 
 
-@layout(pageTitle = titleNoForm(messages("paymentsExtended.title")), showBackLink = false) {
+@layout(pageTitle = titleNoForm(messages("paymentsExtended.title", childName)), showBackLink = false) {
 
-    @panel(messages("paymentsExtended.heading"))
+    @panel(s"${messages("paymentsExtended.heading")}</br>$childName")
     @h2(messages("paymentsExtended.whatHappensNext.h2"))
     @para(messages("paymentsExtended.p1", childName, courseDuration.toMessage))
     @para(messages("paymentsExtended.changeOfCircumstances", changeOfCircumstancesLink))

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -397,8 +397,8 @@ checkYourAnswers.qypChanged = Rydych wedi newid pwy rydych yn rhoi gwybod i ni a
 checkYourAnswers.submit = Anfon
 
 # ----------  Payments Extended ------------
-paymentsExtended.title = Mae’ch taliadau Budd-dal Plant wedi cael eu hymestyn
-paymentsExtended.heading = Mae’ch taliadau Budd-dal Plant wedi cael eu hymestyn
+paymentsExtended.title = Mae CThEF wedi ymestyn eich Budd-dal Plant ar gyfer {0}
+paymentsExtended.heading = Mae CThEF wedi ymestyn eich Budd-dal Plant ar gyfer
 paymentsExtended.whatHappensNext.h2 = Yr hyn sy’n digwydd nesaf
 paymentsExtended.p1 = Bydd y taliadau Budd-dal Plant ar gyfer {0} yn cael eu talu tra bo’r plentyn hwnnw’n parhau ag addysg amser llawn nad yw’n addysg uwch. Byddwch yn cael y taliadau hyn am {1}.
 paymentsExtended.changeOfCircumstances = Mae’n rhaid i chi {0}.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -427,8 +427,8 @@ checkYourAnswers.qypChanged = You changed who you’re telling us about, check y
 checkYourAnswers.submit = Send
 
 # ----------  Payments Extended ------------
-paymentsExtended.title = Your Child Benefit payments have been extended
-paymentsExtended.heading = Your Child Benefit payments have been extended
+paymentsExtended.title = HMRC has extended your Child Benefit for {0}
+paymentsExtended.heading = HMRC has extended your Child Benefit for
 paymentsExtended.whatHappensNext.h2 = What happens next
 paymentsExtended.p1 = The Child Benefit payments for {0} will now be paid while they stay in full-time non-advanced education. You’ll receive the payments for {1}.
 paymentsExtended.changeOfCircumstances = You must {0}.


### PR DESCRIPTION
[[SO-164]](https://jira.tools.tax.service.gov.uk/browse/SO-164)

We display the name of the child in the Confirmation Panel and the title of the page to re-enforce whom the journey was for (previously in the copy below on the page but less obvious).

![SO-164 FTNAE Confirmation - Cymraeg](https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/9a139b11-eb30-44cb-b4df-7fd34f678875)
![SO-164 FTNAE Confirmation - English](https://github.com/hmrc/child-benefit-view-frontend/assets/11579453/d55443f4-0a76-4631-8b0a-d8bb4723586c)
