### PR TITLE
[SO-50] Corrections to visually hidden A11Y text across features

### DIFF
--- a/app/models/viewmodels/ErrorMessageAwareness.scala
+++ b/app/models/viewmodels/ErrorMessageAwareness.scala
@@ -42,6 +42,9 @@ trait ErrorMessageAwareness {
   def errorMessage(field: Field)(implicit messages: Messages): Option[ErrorMessage] =
     field.error
       .map { err =>
-        ErrorMessage(content = Text(messages(err.message, err.args: _*)))
+        ErrorMessage(
+          content = Text(messages(err.message, err.args: _*)),
+          visuallyHiddenText = Some(messages("site.error"))
+        )
       }
 }

--- a/app/views/cob/ChangeAccountView.scala.html
+++ b/app/views/cob/ChangeAccountView.scala.html
@@ -27,7 +27,8 @@
         govukSummaryList: GovukSummaryList,
         link: Link,
         buttonLink: ButtonLink,
-        note: Notification
+        note: Notification,
+        warningText: Warning
 )
 
 @(claimantName: String, accountDetails: ClaimantBankAccountInformation)(implicit request: Request[_], messages: Messages)
@@ -85,13 +86,7 @@
 
     @para(messages("changeAccount.paragraph.1"))
 
-    <div class="govuk-warning-text" id="warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
-            @messages("changeAccount.warning")
-        </strong>
-    </div>
+    @warningText(Html(messages("changeAccount.warning")))
 
     @para(messages("changeAccount.paragraph.2", formLink))
 

--- a/app/views/components/AdditionalScript.scala.html
+++ b/app/views/components/AdditionalScript.scala.html
@@ -1,18 +1,18 @@
 @*
-* Copyright 2023 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
 
 @this()
 @()(implicit request: RequestHeader)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -13,6 +13,8 @@ site.technicalProblemMessage = A yw’r dudalen hon yn gweithio’n iawn?
 site.opensInNewTab = (yn agor tab newydd)
 site.banner = Ni fydd nifer o wasanaethau ar gael o 12:00 prynhawn dydd Gwener, 23 Mehefin, tan 07:00 bore dydd Llun, 26 Mehefin.
 site.bannerLinkText = Dysgwch pa wasanaethau a fydd yn cael eu heffeithio
+site.error = Gwall
+site.warning = Rhybudd:
 
 # ---------- Date Section -----------------------
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -19,6 +19,8 @@ site.technicalProblemMessage = Is this page not working properly?
 site.opensInNewTab = (opens in new tab)
 site.banner = A number of services will be unavailable from 12.00pm on Friday 23 June to 7.00am on Monday 26 June.
 site.bannerLinkText = Find out which services are affected
+site.error = Error
+site.warning = Warning:
 
 # ---------- Date Section -----------------------
 date.day = Day

--- a/test/views/cob/ChangeAccountViewSpec.scala
+++ b/test/views/cob/ChangeAccountViewSpec.scala
@@ -58,7 +58,7 @@ class ChangeAccountViewSpec extends ViewSpecBase {
     }
 
     "have a warning" in {
-      view.getElementById("warning-text").text() must include(messages("changeAccount.warning"))
+      view.getElementsByClass("govuk-warning-text").text() must include(messages("changeAccount.warning"))
     }
 
     "have a secondary heading" when {


### PR DESCRIPTION
[[SO-50](https://jira.tools.tax.service.gov.uk/browse/SO-50)

Fixing a few WGAC issues identified with visually hidden text (typically used by assistive technologies) as identified by our Accessibility Audits.

* The ErrorMessage model we import has an optional parameter to set the visually hidden prefix message for individual error messages which details the the string "Error". This was never overridden but has no been done so with the message "site.error".
* The GovukWarningText component that we import was searching for a message with the key "site.warning", this has been added.
* The ChangeAccountView was using HTML to build out a warning block rather than a standard component and was using hard coded English text, moved to the component to bring it in line and also enable Welsh language.