### PR TITLE
[SO-274] Remove old and redundant TODO statements

### DIFF
--- a/test/controllers/cob/WhatTypeOfAccountControllerSpec.scala
+++ b/test/controllers/cob/WhatTypeOfAccountControllerSpec.scala
@@ -177,7 +177,6 @@ class WhatTypeOfAccountControllerSpec extends BaseISpec with MockitoSugar {
           when(mockSessionRepository.get(userAnswersId))
             .thenReturn(Future.successful(Some(userAnswers)))
 
-          // TODO figure out a better way of mocking this ugh
           when(mockSessionRepository.set(userAnswers.copy(data = expectedUserAnswers.data)))
             .thenReturn(Future.successful(true))
 
@@ -250,7 +249,6 @@ class WhatTypeOfAccountControllerSpec extends BaseISpec with MockitoSugar {
           when(mockSessionRepository.get(userAnswersId))
             .thenReturn(Future.successful(Some(userAnswers)))
 
-          // TODO figure out a better way of mocking this ugh
           when(mockSessionRepository.set(userAnswers.copy(data = expectedUserAnswers.data)))
             .thenReturn(Future.successful(true))
 


### PR DESCRIPTION
[[SO-274]](https://jira.tools.tax.service.gov.uk/browse/SO-274)

Removing some old TODO statements. Mock seems to work fine so if there ever referred to anything less straight-forward, this is no longer the case.