### PR TITLE
SO-279: Complete parity between messages files (and corrections to Journey Recovery discovered)

### DIFF
--- a/app/controllers/actions/DataRequiredAction.scala
+++ b/app/controllers/actions/DataRequiredAction.scala
@@ -37,6 +37,7 @@ import controllers.routes
 import models.requests.{DataRequest, OptionalDataRequest}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionRefiner, Result}
+import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -46,7 +47,7 @@ class DataRequiredActionImpl @Inject() (implicit val executionContext: Execution
 
     request.userAnswers match {
       case None =>
-        Future.successful(Left(Redirect(routes.JourneyRecoveryController.onPageLoad())))
+        Future.successful(Left(Redirect(routes.ServiceUnavailableController.onPageLoad.url)))
       case Some(data) =>
         Future.successful(Right(DataRequest(request.request, request.userId, request.nino, data)))
     }

--- a/app/controllers/actions/FtnaePaymentsExtendedPageDataRequiredAction.scala
+++ b/app/controllers/actions/FtnaePaymentsExtendedPageDataRequiredAction.scala
@@ -55,7 +55,7 @@ class FtnaePaymentsExtendedPageDataRequiredActionImpl @Inject() (
           .get(request.userId)
           .map(maybeData =>
             maybeData.fold[Either[Result, FtnaePaymentsExtendedPageDataRequest[A]]](
-              Left(Redirect(routes.JourneyRecoveryController.onPageLoad()))
+              Left(Redirect(routes.ServiceUnavailableController.onPageLoad.url))
             )(data => Right(FtnaePaymentsExtendedPageDataRequest(request.request, request.userId, request.nino, data)))
           )
 

--- a/app/controllers/ftnae/CheckYourAnswersController.scala
+++ b/app/controllers/ftnae/CheckYourAnswersController.scala
@@ -28,6 +28,7 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import utils.helpers.FtnaeControllerHelper
 import views.html.ftnae.CheckYourAnswersView
 
@@ -71,7 +72,8 @@ class CheckYourAnswersController @Inject() (
     (featureActions.ftnaeAction andThen identify andThen getData andThen requireData) { implicit request =>
       {
 
-        val summaryRows = buildSummaryRows(request)
+//        val summaryRows = buildSummaryRows(request)
+        val summaryRows: Option[List[SummaryListRow]] = None
 
         firstKickedOutOrUnansweredOtherwiseSuccess(request.userAnswers) match {
           case Right(()) =>

--- a/app/controllers/ftnae/CheckYourAnswersController.scala
+++ b/app/controllers/ftnae/CheckYourAnswersController.scala
@@ -71,9 +71,7 @@ class CheckYourAnswersController @Inject() (
   def onPageLoad(): Action[AnyContent] = {
     (featureActions.ftnaeAction andThen identify andThen getData andThen requireData) { implicit request =>
       {
-
-//        val summaryRows = buildSummaryRows(request)
-        val summaryRows: Option[List[SummaryListRow]] = None
+        val summaryRows = buildSummaryRows(request)
 
         firstKickedOutOrUnansweredOtherwiseSuccess(request.userAnswers) match {
           case Right(()) =>

--- a/app/utils/navigation/Navigator.scala
+++ b/app/utils/navigation/Navigator.scala
@@ -65,9 +65,7 @@ class Navigator @Inject() () {
 
   private def navigateWhichYoungPerson(userAnswers: UserAnswers, mode: Mode): Call = {
     val YOUNG_PERSON_NOT_DISPLAYED_INDEX = "0"
-//    val test: Option[String] = None
 
-//    test match {
     userAnswers.get(WhichYoungPersonPage) match {
       case Some(YOUNG_PERSON_NOT_DISPLAYED_INDEX) =>
         controllers.ftnae.routes.WhyYoungPersonNotListedController.onPageLoad()

--- a/app/utils/navigation/Navigator.scala
+++ b/app/utils/navigation/Navigator.scala
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2022 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package utils.navigation
 
 import javax.inject.{Inject, Singleton}
@@ -40,23 +24,24 @@ import models.ftnae.HowManyYears
 import utils.pages._
 import pages.cob.{ConfirmNewAccountDetailsPage, NewAccountDetailsPage, WhatTypeOfAccountPage}
 import pages.ftnae.{HowManyYearsPage, LiveWithYouInUKPage, SchoolOrCollegePage, TwelveHoursAWeekPage, WhichYoungPersonPage, WillCourseBeEmployerProvidedPage, WillYoungPersonBeStayingPage}
+import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 
 @Singleton
 class Navigator @Inject() () {
 
-  private val normalRoutes: Page => UserAnswers => Call = {
-    case WhatTypeOfAccountPage            => _ => controllers.cob.routes.NewAccountDetailsController.onPageLoad(NormalMode)
-    case NewAccountDetailsPage            => _ => controllers.cob.routes.ConfirmNewAccountDetailsController.onPageLoad(NormalMode)
-    case ConfirmNewAccountDetailsPage     => userAnswers => confirmAccountDetails(userAnswers)
-    case WhichYoungPersonPage             => userAnswers => navigateWhichYoungPerson(userAnswers)
-    case WillYoungPersonBeStayingPage     => userAnswers => navigateWillYoungPersonBeStaying(userAnswers)
-    case SchoolOrCollegePage              => userAnswers => navigateSchoolOrCollege(userAnswers)
-    case TwelveHoursAWeekPage             => userAnswers => navigateTwelveHoursAWeek(userAnswers)
-    case HowManyYearsPage                 => userAnswers => navigateHowManyYears(userAnswers)
-    case WillCourseBeEmployerProvidedPage => userAnswers => navigateWillCourseBeEmployerProvided(userAnswers)
-    case LiveWithYouInUKPage              => userAnswers => navigateLiveWithYouIntheUK(userAnswers)
+  private val normalRoutes: Page => (UserAnswers, Mode) => Call = {
+    case WhatTypeOfAccountPage            => (_, _) => controllers.cob.routes.NewAccountDetailsController.onPageLoad(NormalMode)
+    case NewAccountDetailsPage            => (_, _) => controllers.cob.routes.ConfirmNewAccountDetailsController.onPageLoad(NormalMode)
+    case ConfirmNewAccountDetailsPage     => (userAnswers, mode) => confirmAccountDetails(userAnswers, mode)
+    case WhichYoungPersonPage             => (userAnswers, mode) => navigateWhichYoungPerson(userAnswers, mode)
+    case WillYoungPersonBeStayingPage     => (userAnswers, mode) => navigateWillYoungPersonBeStaying(userAnswers, mode)
+    case SchoolOrCollegePage              => (userAnswers, mode) => navigateSchoolOrCollege(userAnswers, mode)
+    case TwelveHoursAWeekPage             => (userAnswers, mode) => navigateTwelveHoursAWeek(userAnswers, mode)
+    case HowManyYearsPage                 => (userAnswers, mode) => navigateHowManyYears(userAnswers, mode)
+    case WillCourseBeEmployerProvidedPage => (userAnswers, mode) => navigateWillCourseBeEmployerProvided(userAnswers, mode)
+    case LiveWithYouInUKPage              => (userAnswers, mode) => navigateLiveWithYouIntheUK(userAnswers, mode)
     case _ @page =>
-      _ => {
+      (_, _) => {
         controllers.routes.ServiceUnavailableController.onPageLoad
       }
   }
@@ -70,63 +55,81 @@ class Navigator @Inject() () {
   def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call = {
     mode match {
       case NormalMode =>
-        normalRoutes(page)(userAnswers)
+        normalRoutes(page)(userAnswers, mode)
       case CheckMode =>
         checkRouteMap(page)(userAnswers)
     }
   }
 
-  private def navigateWhichYoungPerson(userAnswers: UserAnswers): Call = {
+  private def navigateWhichYoungPerson(userAnswers: UserAnswers, mode: Mode): Call = {
     val YOUNG_PERSON_NOT_DISPLAYED_INDEX = "0"
+//    val test: Option[String] = None
 
+//    test match {
     userAnswers.get(WhichYoungPersonPage) match {
       case Some(YOUNG_PERSON_NOT_DISPLAYED_INDEX) =>
         controllers.ftnae.routes.WhyYoungPersonNotListedController.onPageLoad()
       case Some(_) => controllers.ftnae.routes.WillYoungPersonBeStayingController.onPageLoad(NormalMode)
-      case _       => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case _       => controllers.routes.JourneyRecoveryController.onPageLoad(
+        Some(RedirectUrl(controllers.ftnae.routes.WhichYoungPersonController.onPageLoad(mode).url))
+      )
     }
   }
-  private def navigateWillYoungPersonBeStaying(userAnswers: UserAnswers): Call =
+  private def navigateWillYoungPersonBeStaying(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(WillYoungPersonBeStayingPage) match {
       case Some(false) => controllers.ftnae.routes.UseDifferentFormController.onPageLoad()
       case Some(true)  => controllers.ftnae.routes.SchoolOrCollegeController.onPageLoad(NormalMode)
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(
+        Some(RedirectUrl(controllers.ftnae.routes.WillYoungPersonBeStayingController.onPageLoad(mode).url))
+      )
     }
-  private def navigateSchoolOrCollege(userAnswers: UserAnswers): Call =
+  private def navigateSchoolOrCollege(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(SchoolOrCollegePage) match {
       case Some(false) => controllers.ftnae.routes.UseDifferentFormController.onPageLoad()
       case Some(true)  => controllers.ftnae.routes.TwelveHoursAWeekController.onPageLoad(NormalMode)
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(
+        Some(RedirectUrl(controllers.ftnae.routes.SchoolOrCollegeController.onPageLoad(mode).url))
+      )
     }
-  private def navigateTwelveHoursAWeek(userAnswers: UserAnswers): Call =
+  private def navigateTwelveHoursAWeek(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(TwelveHoursAWeekPage) match {
       case Some(false) => controllers.ftnae.routes.NotEntitledController.onPageLoad()
       case Some(true)  => controllers.ftnae.routes.HowManyYearsController.onPageLoad(NormalMode)
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(
+        Some(RedirectUrl(controllers.ftnae.routes.TwelveHoursAWeekController.onPageLoad(mode).url))
+      )
     }
-  private def navigateHowManyYears(userAnswers: UserAnswers): Call =
+  private def navigateHowManyYears(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(HowManyYearsPage) match {
       case Some(HowManyYears.Other) => controllers.ftnae.routes.UseDifferentFormController.onPageLoad()
       case Some(_) =>
         controllers.ftnae.routes.WillCourseBeEmployerProvidedController.onPageLoad(NormalMode)
-      case _ => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case _ => controllers.routes.JourneyRecoveryController.onPageLoad(
+        Some(RedirectUrl(controllers.ftnae.routes.HowManyYearsController.onPageLoad(mode).url))
+      )
     }
-  private def navigateWillCourseBeEmployerProvided(userAnswers: UserAnswers): Call =
+  private def navigateWillCourseBeEmployerProvided(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(WillCourseBeEmployerProvidedPage) match {
       case Some(true)  => controllers.ftnae.routes.NotEntitledCourseEmployerProvidedController.onPageLoad()
       case Some(false) => controllers.ftnae.routes.LiveWithYouInUKController.onPageLoad(NormalMode)
-      case None        => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case None        => controllers.routes.JourneyRecoveryController.onPageLoad(
+        Some(RedirectUrl(controllers.ftnae.routes.WillCourseBeEmployerProvidedController.onPageLoad(mode).url))
+      )
     }
-  private def navigateLiveWithYouIntheUK(userAnswers: UserAnswers): Call =
+  private def navigateLiveWithYouIntheUK(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(LiveWithYouInUKPage) match {
       case Some(true)  => controllers.ftnae.routes.CheckYourAnswersController.onPageLoad()
       case Some(false) => controllers.ftnae.routes.UseDifferentFormController.onPageLoad()
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(
+        Some(RedirectUrl(controllers.ftnae.routes.LiveWithYouInUKController.onPageLoad(mode).url))
+      )
     }
-  private def confirmAccountDetails(userAnswers: UserAnswers): Call =
+  private def confirmAccountDetails(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(ConfirmNewAccountDetailsPage) match {
       case Some(Yes) => controllers.cob.routes.AccountChangedController.onPageLoad()
       case Some(No)  => controllers.cob.routes.WhatTypeOfAccountController.onPageLoad(NormalMode)
-      case _         => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case _         => controllers.routes.JourneyRecoveryController.onPageLoad(
+        Some(RedirectUrl(controllers.cob.routes.ConfirmNewAccountDetailsController.onPageLoad(mode).url))
+      )
     }
 }

--- a/app/utils/navigation/Navigator.scala
+++ b/app/utils/navigation/Navigator.scala
@@ -30,16 +30,18 @@ import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 class Navigator @Inject() () {
 
   private val normalRoutes: Page => (UserAnswers, Mode) => Call = {
-    case WhatTypeOfAccountPage            => (_, _) => controllers.cob.routes.NewAccountDetailsController.onPageLoad(NormalMode)
-    case NewAccountDetailsPage            => (_, _) => controllers.cob.routes.ConfirmNewAccountDetailsController.onPageLoad(NormalMode)
-    case ConfirmNewAccountDetailsPage     => (userAnswers, mode) => confirmAccountDetails(userAnswers, mode)
-    case WhichYoungPersonPage             => (userAnswers, mode) => navigateWhichYoungPerson(userAnswers, mode)
-    case WillYoungPersonBeStayingPage     => (userAnswers, mode) => navigateWillYoungPersonBeStaying(userAnswers, mode)
-    case SchoolOrCollegePage              => (userAnswers, mode) => navigateSchoolOrCollege(userAnswers, mode)
-    case TwelveHoursAWeekPage             => (userAnswers, mode) => navigateTwelveHoursAWeek(userAnswers, mode)
-    case HowManyYearsPage                 => (userAnswers, mode) => navigateHowManyYears(userAnswers, mode)
-    case WillCourseBeEmployerProvidedPage => (userAnswers, mode) => navigateWillCourseBeEmployerProvided(userAnswers, mode)
-    case LiveWithYouInUKPage              => (userAnswers, mode) => navigateLiveWithYouIntheUK(userAnswers, mode)
+    case WhatTypeOfAccountPage => (_, _) => controllers.cob.routes.NewAccountDetailsController.onPageLoad(NormalMode)
+    case NewAccountDetailsPage =>
+      (_, _) => controllers.cob.routes.ConfirmNewAccountDetailsController.onPageLoad(NormalMode)
+    case ConfirmNewAccountDetailsPage => (userAnswers, mode) => confirmAccountDetails(userAnswers, mode)
+    case WhichYoungPersonPage         => (userAnswers, mode) => navigateWhichYoungPerson(userAnswers, mode)
+    case WillYoungPersonBeStayingPage => (userAnswers, mode) => navigateWillYoungPersonBeStaying(userAnswers, mode)
+    case SchoolOrCollegePage          => (userAnswers, mode) => navigateSchoolOrCollege(userAnswers, mode)
+    case TwelveHoursAWeekPage         => (userAnswers, mode) => navigateTwelveHoursAWeek(userAnswers, mode)
+    case HowManyYearsPage             => (userAnswers, mode) => navigateHowManyYears(userAnswers, mode)
+    case WillCourseBeEmployerProvidedPage =>
+      (userAnswers, mode) => navigateWillCourseBeEmployerProvided(userAnswers, mode)
+    case LiveWithYouInUKPage => (userAnswers, mode) => navigateLiveWithYouIntheUK(userAnswers, mode)
     case _ @page =>
       (_, _) => {
         controllers.routes.ServiceUnavailableController.onPageLoad
@@ -70,66 +72,74 @@ class Navigator @Inject() () {
       case Some(YOUNG_PERSON_NOT_DISPLAYED_INDEX) =>
         controllers.ftnae.routes.WhyYoungPersonNotListedController.onPageLoad()
       case Some(_) => controllers.ftnae.routes.WillYoungPersonBeStayingController.onPageLoad(NormalMode)
-      case _       => controllers.routes.JourneyRecoveryController.onPageLoad(
-        Some(RedirectUrl(controllers.ftnae.routes.WhichYoungPersonController.onPageLoad(mode).url))
-      )
+      case _ =>
+        controllers.routes.JourneyRecoveryController.onPageLoad(
+          Some(RedirectUrl(controllers.ftnae.routes.WhichYoungPersonController.onPageLoad(mode).url))
+        )
     }
   }
   private def navigateWillYoungPersonBeStaying(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(WillYoungPersonBeStayingPage) match {
       case Some(false) => controllers.ftnae.routes.UseDifferentFormController.onPageLoad()
       case Some(true)  => controllers.ftnae.routes.SchoolOrCollegeController.onPageLoad(NormalMode)
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(
-        Some(RedirectUrl(controllers.ftnae.routes.WillYoungPersonBeStayingController.onPageLoad(mode).url))
-      )
+      case _ =>
+        controllers.routes.JourneyRecoveryController.onPageLoad(
+          Some(RedirectUrl(controllers.ftnae.routes.WillYoungPersonBeStayingController.onPageLoad(mode).url))
+        )
     }
   private def navigateSchoolOrCollege(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(SchoolOrCollegePage) match {
       case Some(false) => controllers.ftnae.routes.UseDifferentFormController.onPageLoad()
       case Some(true)  => controllers.ftnae.routes.TwelveHoursAWeekController.onPageLoad(NormalMode)
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(
-        Some(RedirectUrl(controllers.ftnae.routes.SchoolOrCollegeController.onPageLoad(mode).url))
-      )
+      case _ =>
+        controllers.routes.JourneyRecoveryController.onPageLoad(
+          Some(RedirectUrl(controllers.ftnae.routes.SchoolOrCollegeController.onPageLoad(mode).url))
+        )
     }
   private def navigateTwelveHoursAWeek(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(TwelveHoursAWeekPage) match {
       case Some(false) => controllers.ftnae.routes.NotEntitledController.onPageLoad()
       case Some(true)  => controllers.ftnae.routes.HowManyYearsController.onPageLoad(NormalMode)
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(
-        Some(RedirectUrl(controllers.ftnae.routes.TwelveHoursAWeekController.onPageLoad(mode).url))
-      )
+      case _ =>
+        controllers.routes.JourneyRecoveryController.onPageLoad(
+          Some(RedirectUrl(controllers.ftnae.routes.TwelveHoursAWeekController.onPageLoad(mode).url))
+        )
     }
   private def navigateHowManyYears(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(HowManyYearsPage) match {
       case Some(HowManyYears.Other) => controllers.ftnae.routes.UseDifferentFormController.onPageLoad()
       case Some(_) =>
         controllers.ftnae.routes.WillCourseBeEmployerProvidedController.onPageLoad(NormalMode)
-      case _ => controllers.routes.JourneyRecoveryController.onPageLoad(
-        Some(RedirectUrl(controllers.ftnae.routes.HowManyYearsController.onPageLoad(mode).url))
-      )
+      case _ =>
+        controllers.routes.JourneyRecoveryController.onPageLoad(
+          Some(RedirectUrl(controllers.ftnae.routes.HowManyYearsController.onPageLoad(mode).url))
+        )
     }
   private def navigateWillCourseBeEmployerProvided(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(WillCourseBeEmployerProvidedPage) match {
       case Some(true)  => controllers.ftnae.routes.NotEntitledCourseEmployerProvidedController.onPageLoad()
       case Some(false) => controllers.ftnae.routes.LiveWithYouInUKController.onPageLoad(NormalMode)
-      case None        => controllers.routes.JourneyRecoveryController.onPageLoad(
-        Some(RedirectUrl(controllers.ftnae.routes.WillCourseBeEmployerProvidedController.onPageLoad(mode).url))
-      )
+      case None =>
+        controllers.routes.JourneyRecoveryController.onPageLoad(
+          Some(RedirectUrl(controllers.ftnae.routes.WillCourseBeEmployerProvidedController.onPageLoad(mode).url))
+        )
     }
   private def navigateLiveWithYouIntheUK(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(LiveWithYouInUKPage) match {
       case Some(true)  => controllers.ftnae.routes.CheckYourAnswersController.onPageLoad()
       case Some(false) => controllers.ftnae.routes.UseDifferentFormController.onPageLoad()
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(
-        Some(RedirectUrl(controllers.ftnae.routes.LiveWithYouInUKController.onPageLoad(mode).url))
-      )
+      case _ =>
+        controllers.routes.JourneyRecoveryController.onPageLoad(
+          Some(RedirectUrl(controllers.ftnae.routes.LiveWithYouInUKController.onPageLoad(mode).url))
+        )
     }
   private def confirmAccountDetails(userAnswers: UserAnswers, mode: Mode): Call =
     userAnswers.get(ConfirmNewAccountDetailsPage) match {
       case Some(Yes) => controllers.cob.routes.AccountChangedController.onPageLoad()
       case Some(No)  => controllers.cob.routes.WhatTypeOfAccountController.onPageLoad(NormalMode)
-      case _         => controllers.routes.JourneyRecoveryController.onPageLoad(
-        Some(RedirectUrl(controllers.cob.routes.ConfirmNewAccountDetailsController.onPageLoad(mode).url))
-      )
+      case _ =>
+        controllers.routes.JourneyRecoveryController.onPageLoad(
+          Some(RedirectUrl(controllers.cob.routes.ConfirmNewAccountDetailsController.onPageLoad(mode).url))
+        )
     }
 }

--- a/app/views/JourneyRecoveryContinueView.scala.html
+++ b/app/views/JourneyRecoveryContinueView.scala.html
@@ -32,7 +32,7 @@
     @para(messages("journeyRecovery.continue.guidance"))
 
     @govukButton(
-        ButtonViewModel(messages("site.continue"))
+        ButtonViewModel(messages("journeyRecovery.continue.button"))
             .asLink(continueUrl)
             .withAttribute("id", "continue-button")
     )

--- a/app/views/JourneyRecoveryStartAgainView.scala.html
+++ b/app/views/JourneyRecoveryStartAgainView.scala.html
@@ -32,7 +32,8 @@
     @para(messages("journeyRecovery.startAgain.guidance"))
 
     @govukButton(
-        ButtonViewModel(messages("site.startAgain"))
+        ButtonViewModel(messages("journeyRecovery.startAgain.button"))
+            .asLink(controllers.routes.ProofOfEntitlementController.view.url)
             .withAttribute("id", "start-again-button")
     )
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1,8 +1,6 @@
-label.back.link=Yn ôl
-
 service.name = Budd-dal Plant
 
-# ---------- Site Section -----------------------
+# ---------- Site Section -----------------------SS
 site.change = Newid
 site.no = Na
 site.yes = Iawn
@@ -16,7 +14,14 @@ site.bannerLinkText = Dysgwch pa wasanaethau a fydd yn cael eu heffeithio
 site.error = Gwall
 site.warning = Rhybudd:
 
+# ---------- Label Section -----------------------
+label.back.link = Yn ôl
+
+
 # ---------- Date Section -----------------------
+date.day = Diwrnod
+date.month = Mis
+date.year = Blwyddyn
 
 # ---------- Timeout Section --------------------
 timeout.title = Rydych ar fin cael eich allgofnodi

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1,10 +1,14 @@
 service.name = Budd-dal Plant
 
-# ---------- Site Section -----------------------SS
+# ---------- Site Section -----------------------
+site.back = Yn ôl
+site.remove = Tynnu
 site.change = Newid
 site.no = Na
 site.yes = Iawn
 site.continue = Yn eich blaen
+site.start = Dechrau nawr
+site.startAgain = Dechrau eto
 site.signIn = Mewngofnodi
 site.govuk = GOV.UK
 site.technicalProblemMessage = A yw’r dudalen hon yn gweithio’n iawn?
@@ -33,6 +37,14 @@ timeout.signOut = Allgofnodi
 error.browser.title.prefix = Gwall:
 
 # ---------- Journey Recovery Section -----------
+journeyRecovery.continue.title = Mae’n ddrwg gennym, ond mae problem gyda’r gwasanaeth
+journeyRecovery.continue.heading = Mae’n ddrwg gennym, ond mae problem gyda’r gwasanaeth
+journeyRecovery.continue.guidance = Nid oeddem yn gallu cadw’ch ateb diwethaf. I fynd yn eich blaen, mae angen i chi roi cynnig arall arni.
+journeyRecovery.continue.button = Rhowch gynnig arall arni
+journeyRecovery.startAgain.title = Rhowch gynnig arall arni
+journeyRecovery.startAgain.heading = Mae’n ddrwg gennym, ond mae problem gyda’r gwasanaeth
+journeyRecovery.startAgain.guidance = Mae’n ddrwg gennym, ond mae problem gyda’r gwasanaeth
+journeyRecovery.startAgain.button = Dechrau eto
 
 # ---------- Signed Out Section -----------------
 signedOut.title = Er eich diogelwch, gwnaethom eich allgofnodi
@@ -137,6 +149,9 @@ notFound.explanation1 = Os gwnaethoch deipio’r cyfeiriad gwe, gwiriwch ei fod 
 notFound.explanation2 = Os gwnaethoch ludo’r cyfeiriad gwe, gwiriwch eich bod wedi copïo’r cyfeiriad yn llawn.
 
 # ---------- Page Not Found Section -------------
+pageNotFound.title = Heb ddod o hyd i’r dudalen
+pageNotFound.heading = Ni ellir dod o hyd i’r dudalen hon
+pageNotFound.paragraph1 = Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
 
 # ---------- Change Account Section -------------
 changeAccount.title = Caiff eich Budd-dal Plant ei dalu i’r cyfrif hwn
@@ -303,7 +318,6 @@ extendPayments.bulletPoint10 = ar gwrs sy’n cael ei ddarparu gan ysgol neu gol
 extendPayments.bulletPoint11 = yn byw gyda chi yn y DU
 extendPayments.p4 = Defnyddiwch ffurflen wahanol i wneud cais {0}.
 extendPayments.p4.linkText = os bydd ei amgylchiadau’n wahanol
-extendPayments.govuk.link = https://www.gov.uk/government/publications/child-benefit-child-continuing-in-approved-education-or-training-ch297.cy
 
 # ----------  Young person not listed for FTNAE ------------
 whyYoungPersonNotListed.title = Pam nad yw’r person ifanc wedi’i restru

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -38,10 +38,12 @@ error.browser.title.prefix = Error:
 # ---------- Journey Recovery Section -----------
 journeyRecovery.continue.title = Sorry, there is a problem with the service
 journeyRecovery.continue.heading = Sorry, there is a problem with the service
-journeyRecovery.continue.guidance = [Add content to explain how to proceed.]
+journeyRecovery.continue.guidance = We were unable to save your last answer. To continue, you need to try again.
+journeyRecovery.continue.button = Try again
 journeyRecovery.startAgain.title = Sorry, there is a problem with the service
 journeyRecovery.startAgain.heading = Sorry, there is a problem with the service
-journeyRecovery.startAgain.guidance = [Add content to explain why the user needs to start again.]
+journeyRecovery.startAgain.guidance = There is an issue with this service so we have been unable to save your answers. To continue, you will have to start again.
+journeyRecovery.startAgain.button = Start again
 
 # ---------- Signed Out Section -----------------
 signedOut.title = For your security, we signed you out

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,8 +1,4 @@
-label.back.link=Back
-
 service.name = Child Benefit
-appName = "sca-apply-chb-frontend"
-sca-apply-chb-frontend = Apply CHB Frontend
 
 # ---------- Site Section -----------------------
 site.back = Back
@@ -22,6 +18,9 @@ site.bannerLinkText = Find out which services are affected
 site.error = Error
 site.warning = Warning:
 
+# ---------- Label Section -----------------------
+label.back.link = Back
+
 # ---------- Date Section -----------------------
 date.day = Day
 date.month = Month
@@ -35,19 +34,6 @@ timeout.signOut = Sign out
 
 # ---------- Error Section ----------------------
 error.browser.title.prefix = Error:
-error.boolean = Please give an answer
-error.invalid_date = Give a correct date
-error.date.day_blank = Enter a day
-error.date.day_invalid = Give a correct day using numbers 1 to 31
-error.date.month_blank = Enter a month
-error.date.month_invalid = Give a correct month using numbers 1 to 12
-error.date.year_blank = Enter a year
-error.date.year_invalid = Give a correct year
-error.integer = Give an answer in whole numbers
-error.non_numeric = Give a value using only numbers
-error.number = Please enter a valid number
-error.required = Please enter a value
-error.summary.title = There is a problem
 
 # ---------- Journey Recovery Section -----------
 journeyRecovery.continue.title = Sorry, there is a problem with the service

--- a/test/controllers/actions/FtnaePaymentsExtendedPageDataRequiredActionSpec.scala
+++ b/test/controllers/actions/FtnaePaymentsExtendedPageDataRequiredActionSpec.scala
@@ -67,7 +67,7 @@ class FtnaePaymentsExtendedPageDataRequiredActionSpec extends BaseISpec with Moc
         val result = action
           .callTransform(OptionalDataRequest(fakeRequest, "id", nino, None))
           .futureValue
-        result mustBe Left(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+        result mustBe Left(Redirect(controllers.routes.ServiceUnavailableController.onPageLoad.url))
       }
     }
 

--- a/test/controllers/ftnae/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/ftnae/CheckYourAnswersControllerSpec.scala
@@ -93,7 +93,7 @@ class CheckYourAnswersControllerSpec extends BaseISpec with SummaryListFluency w
       }
     }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+    "must redirect to Service Unavailable for a GET if no existing data is found" in {
       userLoggedInChildBenefitUser(NinoUser)
 
       val application = applicationBuilder(config, userAnswers = None).configure().build()
@@ -105,7 +105,7 @@ class CheckYourAnswersControllerSpec extends BaseISpec with SummaryListFluency w
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
 

--- a/test/controllers/ftnae/HowManyYearsControllerSpec.scala
+++ b/test/controllers/ftnae/HowManyYearsControllerSpec.scala
@@ -154,7 +154,7 @@ class HowManyYearsControllerSpec extends CBSpecBase with MockitoSugar {
       }
     }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+    "must redirect to Service Unavailable for a GET if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -164,11 +164,11 @@ class HowManyYearsControllerSpec extends CBSpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
 
-    "redirect to Journey Recovery for a POST if no existing data is found" in {
+    "redirect to Service Unavailable for a POST if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -181,7 +181,7 @@ class HowManyYearsControllerSpec extends CBSpecBase with MockitoSugar {
 
         status(result) mustEqual SEE_OTHER
 
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
   }

--- a/test/controllers/ftnae/LiveWithYouInUKControllerSpec.scala
+++ b/test/controllers/ftnae/LiveWithYouInUKControllerSpec.scala
@@ -197,7 +197,7 @@ class LiveWithYouInUKControllerSpec extends CBSpecBase with MockitoSugar {
       }
     }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+    "must redirect to Service Unavailable for a GET if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -207,11 +207,11 @@ class LiveWithYouInUKControllerSpec extends CBSpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
 
-    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+    "must redirect to Service Unavailable for a POST if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -223,7 +223,7 @@ class LiveWithYouInUKControllerSpec extends CBSpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
   }

--- a/test/controllers/ftnae/SchoolOrCollegeControllerSpec.scala
+++ b/test/controllers/ftnae/SchoolOrCollegeControllerSpec.scala
@@ -165,7 +165,7 @@ class SchoolOrCollegeControllerSpec extends CBSpecBase with MockitoSugar {
       }
     }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+    "must redirect to Service Unavailable for a GET if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -175,11 +175,11 @@ class SchoolOrCollegeControllerSpec extends CBSpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
 
-    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+    "must redirect to Service Unavailable for a POST if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -191,7 +191,7 @@ class SchoolOrCollegeControllerSpec extends CBSpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
   }

--- a/test/controllers/ftnae/TwelveHoursAWeekControllerSpec.scala
+++ b/test/controllers/ftnae/TwelveHoursAWeekControllerSpec.scala
@@ -187,7 +187,7 @@ class TwelveHoursAWeekControllerSpec extends CBSpecBase with MockitoSugar {
       }
     }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+    "must redirect to Service Unavailable for a GET if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -197,11 +197,11 @@ class TwelveHoursAWeekControllerSpec extends CBSpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
 
-    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+    "must redirect to Service Unavailable for a POST if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -213,7 +213,7 @@ class TwelveHoursAWeekControllerSpec extends CBSpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
   }

--- a/test/controllers/ftnae/WillCourseBeEmployerProvidedControllerSpec.scala
+++ b/test/controllers/ftnae/WillCourseBeEmployerProvidedControllerSpec.scala
@@ -221,7 +221,7 @@ class WillCourseBeEmployerProvidedControllerSpec extends CBSpecBase with Mockito
       }
     }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+    "must redirect to Service Unavailable for a GET if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -231,11 +231,11 @@ class WillCourseBeEmployerProvidedControllerSpec extends CBSpecBase with Mockito
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
 
-    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+    "must redirect to Service Unavailable for a POST if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -247,7 +247,7 @@ class WillCourseBeEmployerProvidedControllerSpec extends CBSpecBase with Mockito
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
   }

--- a/test/controllers/ftnae/WillYoungPersonBeStayingControllerSpec.scala
+++ b/test/controllers/ftnae/WillYoungPersonBeStayingControllerSpec.scala
@@ -189,7 +189,7 @@ class WillYoungPersonBeStayingControllerSpec extends CBSpecBase with MockitoSuga
       }
     }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+    "must redirect to Service Unavailable for a GET if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -199,11 +199,11 @@ class WillYoungPersonBeStayingControllerSpec extends CBSpecBase with MockitoSuga
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
 
-    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+    "must redirect to Service Unavailable for a POST if no existing data is found" in {
 
       val application = applicationBuilder(userAnswers = None).build()
 
@@ -215,7 +215,7 @@ class WillYoungPersonBeStayingControllerSpec extends CBSpecBase with MockitoSuga
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual controllers.routes.ServiceUnavailableController.onPageLoad.url
       }
     }
   }

--- a/test/messages/MessagesSpec.scala
+++ b/test/messages/MessagesSpec.scala
@@ -9,11 +9,11 @@ import scala.io.Source
 
 class MessagesSpec extends AnyFreeSpec with Matchers {
 
-  private val MatchSingleQuoteOnly = """\w+'{1}\w+""".r
+  private val MatchSingleQuoteOnly   = """\w+'{1}\w+""".r
   private val MatchBacktickQuoteOnly = """`+""".r
 
   private val englishMessages = parseMessages("conf/messages.en").filterNot(message => message._1.startsWith("pdf"))
-  private val welshMessages = parseMessages("conf/messages.cy")
+  private val welshMessages   = parseMessages("conf/messages.cy")
 
   "All message files" - {
     "have the same set of keys" in {
@@ -46,22 +46,24 @@ class MessagesSpec extends AnyFreeSpec with Matchers {
     }
 
   private def assertNonEmpty(label: String, messages: Map[String, String]): Unit =
-    messages.foreach { case (key: String, value: String) =>
-      withClue(
-        s"In $label, there is an empty value for the key:[$key][$value]"
-      ) {
-        value.trim.isEmpty mustBe false
-      }
+    messages.foreach {
+      case (key: String, value: String) =>
+        withClue(
+          s"In $label, there is an empty value for the key:[$key][$value]"
+        ) {
+          value.trim.isEmpty mustBe false
+        }
     }
 
   private def assertCorrectUseOfQuotes(label: String, messages: Map[String, String]): Unit =
-    messages.foreach { case (key: String, value: String) =>
-      withClue(
-        s"In $label, there is an unescaped or invalid quote:[$key][$value]"
-      ) {
-        MatchSingleQuoteOnly.findFirstIn(value).isDefined mustBe false
-        MatchBacktickQuoteOnly.findFirstIn(value).isDefined mustBe false
-      }
+    messages.foreach {
+      case (key: String, value: String) =>
+        withClue(
+          s"In $label, there is an unescaped or invalid quote:[$key][$value]"
+        ) {
+          MatchSingleQuoteOnly.findFirstIn(value).isDefined mustBe false
+          MatchBacktickQuoteOnly.findFirstIn(value).isDefined mustBe false
+        }
     }
 
   private def listMissingMessageKeys(header: String, missingKeys: Set[String]) = {

--- a/test/messages/MessagesSpec.scala
+++ b/test/messages/MessagesSpec.scala
@@ -1,0 +1,85 @@
+package utils
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.i18n.Messages
+import play.api.i18n.Messages.MessageSource
+
+import scala.io.Source
+
+class MessagesSpec extends AnyFreeSpec with Matchers {
+
+  private val MatchSingleQuoteOnly = """\w+'{1}\w+""".r
+  private val MatchBacktickQuoteOnly = """`+""".r
+
+  private val englishMessages = parseMessages("conf/messages.en").filterNot(message => message._1.startsWith("pdf"))
+  private val welshMessages = parseMessages("conf/messages.cy")
+
+  "All message files" - {
+    "have the same set of keys" in {
+      withClue(describeMismatch(englishMessages.keySet, welshMessages.keySet)) {
+        welshMessages.keySet mustBe englishMessages.keySet
+      }
+    }
+
+    "have a non-empty message for each key" in {
+      assertNonEmpty("English", englishMessages)
+      assertNonEmpty("Welsh", welshMessages)
+    }
+
+    "have no unescaped single quotes in value" in {
+      assertCorrectUseOfQuotes("English", englishMessages)
+      assertCorrectUseOfQuotes("Welsh", welshMessages)
+    }
+
+  }
+
+  private def parseMessages(filename: String): Map[String, String] =
+    Messages.parse(
+      new MessageSource {
+        override def read: String = Source.fromFile(filename).mkString
+      },
+      filename
+    ) match {
+      case Right(messages) => messages
+      case Left(e)         => throw e
+    }
+
+  private def assertNonEmpty(label: String, messages: Map[String, String]): Unit =
+    messages.foreach { case (key: String, value: String) =>
+      withClue(
+        s"In $label, there is an empty value for the key:[$key][$value]"
+      ) {
+        value.trim.isEmpty mustBe false
+      }
+    }
+
+  private def assertCorrectUseOfQuotes(label: String, messages: Map[String, String]): Unit =
+    messages.foreach { case (key: String, value: String) =>
+      withClue(
+        s"In $label, there is an unescaped or invalid quote:[$key][$value]"
+      ) {
+        MatchSingleQuoteOnly.findFirstIn(value).isDefined mustBe false
+        MatchBacktickQuoteOnly.findFirstIn(value).isDefined mustBe false
+      }
+    }
+
+  private def listMissingMessageKeys(header: String, missingKeys: Set[String]) = {
+    val displayLine = "\n" + ("@" * 42) + "\n"
+    missingKeys.toList.sorted.mkString(header + displayLine, "\n", displayLine)
+  }
+
+  private def describeMismatch(englishKeySet: Set[String], welshKeySet: Set[String]) = {
+
+    if (englishKeySet.size > welshKeySet.size)
+      listMissingMessageKeys(
+        "The following message keys are missing from the Welsh Set:",
+        englishKeySet -- welshKeySet
+      )
+    else
+      listMissingMessageKeys(
+        "The following message keys are missing from the English Set:",
+        welshKeySet -- englishKeySet
+      )
+  }
+}


### PR DESCRIPTION
[[SO-297]|https://jira.tools.tax.service.gov.uk/browse/SO-279]

Update message files for parity and a new Unit Test that will check for this.

Also, made some corrections to the use of the JourneyRecovery route that came out of discovering that this was still running the the default place holder text and hadn't been fully configured.